### PR TITLE
Fix cascading failure when opening graphs

### DIFF
--- a/lib/cgraph/cghdr.h
+++ b/lib/cgraph/cghdr.h
@@ -142,6 +142,7 @@ int aagparse(void);
 void aglexinit(Agdisc_t * disc, void *ifile);
 int aaglex(void);
 void aglexeof(void);
+void aglexbad(void);
 
 	/* ID management */
 int agmapnametoid(Agraph_t * g, int objtype, char *str,

--- a/lib/cgraph/grammar.y
+++ b/lib/cgraph/grammar.y
@@ -580,6 +580,7 @@ Agraph_t *agconcat(Agraph_t *g, void *chan, Agdisc_t *disc)
 	Disc = (disc? disc :  &AgDefaultDisc);
 	aglexinit(Disc, chan);
 	yyparse();
+	if (Ag_G_global == NILgraph) aglexbad();
 	return Ag_G_global;
 }
 

--- a/lib/cgraph/scan.l
+++ b/lib/cgraph/scan.l
@@ -211,6 +211,8 @@ void yyerror(char *str)
 /* must be here to see flex's macro defns */
 void aglexeof() { unput(GRAPH_EOF_TOKEN); }
 
+void aglexbad() { YY_FLUSH_BUFFER; }
+
 #ifndef YY_CALL_ONLY_ARG
 # define YY_CALL_ONLY_ARG void
 #endif


### PR DESCRIPTION
When cgraph fails to open a graph, all subsequent graphs will also fail to open. The fix is to flush the lexer state.

This fixes Instaviz issue [253](http://redmine.pixelglow.com/issues/253).
