### PR TITLE
Fix small leak in ortho

### DIFF
--- a/lib/ortho/ortho.c
+++ b/lib/ortho/ortho.c
@@ -1369,6 +1369,7 @@ orthofinish:
 	free (route_list[i].segs);
     free (route_list);
     freeMaze (mp);
+    free (es);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
`es` was allocated but not freed.

This fixes Instaviz issue [268](http://redmine.pixelglow.com/issues/268).
