### PR TITLE
Fix missing CoreText symbol in Leopard builds

### DIFF
--- a/plugin/quartz/gvtextlayout_quartz.c
+++ b/plugin/quartz/gvtextlayout_quartz.c
@@ -27,6 +27,11 @@
 
 #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050 || __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 30200
 
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060
+/* symbol defined in 10.5.x dylib but not in headers */
+extern const CFStringRef kCTForegroundColorFromContextAttributeName;
+#endif
+
 void *quartz_new_layout(char* fontname, double fontsize, char* text)
 {
 	CFStringRef fontnameref = CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8 *)fontname, strlen(fontname), kCFStringEncodingUTF8, FALSE);


### PR DESCRIPTION
When building on Leopard a.k.a. Mac OS X 10.5.x, the `kCTForegroundColorFromContextAttributeName` symbol is present in the dylib but not in the supplied headers. This fix should reenable building on a Leopard machine.

Fixes [Graphviz issue 2405](http://www.graphviz.org/mantisbt/view.php?id=2405).
