### PR TITLE
Add missing include path lib/common for cmd/edgepaint.

### DIFF
--- a/cmd/edgepaint/Makefile.am
+++ b/cmd/edgepaint/Makefile.am
@@ -5,6 +5,7 @@ pdfdir = $(pkgdatadir)/doc/pdf
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-I$(top_srcdir)/lib/common \
 	-I$(top_srcdir)/lib/sparse \
 	-I$(top_srcdir)/lib/sfdpgen \
 	-I$(top_srcdir)/lib/edgepaint \


### PR DESCRIPTION
pointset.h included by edgepaintmain.c exists in lib/common. Thus, -I flag for it is necessary. Without it, at least, build of 2.38.0 on Cygwin fails.
