### PR TITLE
Additional agerr() format string fixes

### DIFF
--- a/cmd/tools/gmlscan.l
+++ b/cmd/tools/gmlscan.l
@@ -127,7 +127,7 @@ void yyerror(char *str)
 	return;
     errors = 1;
     sprintf(buf," %s in line %d near '%s'\n", str,line_num,yytext);
-    agerr(AGWARN,buf);
+    agerr(AGWARN, "%s", buf);
 }
 
 int gmlerrors()

--- a/lib/cgraph/scan.l
+++ b/lib/cgraph/scan.l
@@ -165,7 +165,7 @@ static int chkNum(void) {
 	agxbput(&xb,buf);
 	agxbput(&xb,fname);
 	agxbput(&xb, " splits into two tokens\n");
-	agerr(AGWARN,agxbuse(&xb));
+	agerr(AGWARN, "%s", agxbuse(&xb));
 
 	agxbfree(&xb);
 	return 1;

--- a/lib/graph/lexer.c
+++ b/lib/graph/lexer.c
@@ -460,16 +460,16 @@ static void error_context(void)
     if (buf < p) {
 	c = *p;
 	*p = '\0';
-	agerr(AGPREV, buf);
+	agerr(AGPREV, "%s", buf);
 	*p = c;
     }
     agerr(AGPREV, " >>> ");
     c = *LexPtr;
     *LexPtr = '\0';
-    agerr(AGPREV, p);
+    agerr(AGPREV, "%s", p);
     *LexPtr = c;
     agerr(AGPREV, " <<< ");
-    agerr(AGPREV, LexPtr);
+    agerr(AGPREV, "%s", LexPtr);
 }
 
 void agerror(char *msg)


### PR DESCRIPTION
Similar to fix in commit 99eda42 applied to other places where agerr() was called incorrectly.  See https://github.com/ellson/graphviz/commit/99eda42#commitcomment-11271315 for further discussion.