### PR TITLE
Fix missing agbindrec's

### DIFF
--- a/lib/circogen/blockpath.c
+++ b/lib/circogen/blockpath.c
@@ -45,6 +45,7 @@ static Agraph_t *clone_graph(Agraph_t * ing, Agraph_t ** xg)
     agbindrec(clone, "Agraphinfo_t", sizeof(Agraphinfo_t), TRUE);	//node custom data
     sprintf(gname, "_clone_%d", id++);
     xclone = agopen(gname, ing->desc,NIL(Agdisc_t *));
+    agbindrec(xclone, "Agraphinfo_t", sizeof(Agraphinfo_t), TRUE);	//node custom data
     for (n = agfstnode(ing); n; n = agnxtnode(ing, n)) {
 	agsubnode(clone,n,1);
 	xn = agnode(xclone, agnameof(n),1);

--- a/lib/fdpgen/layout.c
+++ b/lib/fdpgen/layout.c
@@ -1003,6 +1003,15 @@ static void setBB(graph_t * g)
     }
 }
 
+static void
+fdp_init_subg(graph_t * g)
+{
+    graph_t* subg;
+    agbindrec(g, "Agraphinfo_t", sizeof(Agraphinfo_t), TRUE);
+    for (subg = agfstsubg(g); subg; subg = agnxtsubg(subg))
+        fdp_init_subg(subg);
+}
+
 /* init_info:
  * Initialize graph-dependent information and
  * state variable.s
@@ -1066,6 +1075,10 @@ void fdp_init_graph(Agraph_t * g)
     GD_alg(g) = (void *) NEW(gdata);	/* freed in cleanup_graph */
     GD_ndim(g) = late_int(g, agattr(g,AGRAPH, "dim", NULL), 2, 2);
     Ndim = GD_ndim(g) = MIN(GD_ndim(g), MAXDIM);
+
+    graph_t* subg;
+    for (subg = agfstsubg(g); subg; subg = agnxtsubg(subg))
+        fdp_init_subg(subg);
 
     mkClusters (g, NULL, g);
     fdp_initParams(g);

--- a/lib/neatogen/constraint.c
+++ b/lib/neatogen/constraint.c
@@ -371,6 +371,7 @@ static graph_t *mkConstraintG(graph_t * g, Dt_t * list,
      * FIX: Incremental algorithm to construct trans. reduction?
      */
     vg = agopen("vg", Agstrictdirected, NIL(Agdisc_t *));
+    agbindrec(vg, "Agraphinfo_t", sizeof(Agraphinfo_t), TRUE);	//node custom data
     for (p = (nitem *) dtflatten(list); p;
 	 p = (nitem *) dtlink(list, (Dtlink_t *) p)) {
 	n = agnode(vg, agnameof(p->np), 1);  /* FIX */


### PR DESCRIPTION
In layout code, each graph and subgraph should have an associated `Agraphinfo_t` record. This fixes a couple of places where this record wasn't bound.