### PR TITLE
Put empty names in quotes

### DIFF
--- a/lib/agraph/write.c
+++ b/lib/agraph/write.c
@@ -261,7 +261,7 @@ static void write_hdr(Agraph_t * g, iochan_t * ofile, int top)
     name = agnameof(g);
     sep = " ";
     if (!name || name[0] == LOCALNAMEPREFIX)
-	sep = name = "";
+	name = "\"\"";
     indent(g, ofile);
     ioput(g, ofile, strict);
 


### PR DESCRIPTION
When the name of the graph is empty, you should put that in quotes, because elsewise the title will be something like %3. That is really annoying and currently there is no way to put "", because when you name the graph "" it will translate it to &quot; 
This should not break any existing code, but please **TEST THIS**, because I was not able to build it and/or build the python bindings, because on my system (arch) python is a symlink for python3 and that will break everything.
