### PR TITLE
Fix PointSet leak when inserting same point

### DIFF
--- a/lib/common/pointset.c
+++ b/lib/common/pointset.c
@@ -72,16 +72,23 @@ void freePS(PointSet * ps)
 
 void insertPS(PointSet * ps, point pt)
 {
-    dtinsert(ps, mkPair(pt));
+    pair *pp;
+
+    pp = mkPair(pt);
+    if (dtinsert(ps, pp) != pp)
+        free(pp);
 }
 
 void addPS(PointSet * ps, int x, int y)
 {
     point pt;
+    pair *pp;
 
     pt.x = x;
     pt.y = y;
-    dtinsert(ps, mkPair(pt));
+    pp = mkPair(pt);
+    if (dtinsert(ps, pp) != pp)
+        free(pp);
 }
 
 int inPS(PointSet * ps, point pt)


### PR DESCRIPTION
The old code allocates a `pair` then inserts it into a `Dtoset`. However, when the `Dtoset` already has the `pair`, it simply drops the allocated pair. The fix cleans up the `pair` in this case.