### PR TITLE
Allow relative URL in Graphviz.app

### DIFF
--- a/macosx/GVWindowController.h
+++ b/macosx/GVWindowController.h
@@ -34,6 +34,8 @@
 
 - (IBAction)printGraphDocument:(id)sender;
 
+- (void)PDFViewWillClickOnLink:(PDFView *)sender withURL:(NSURL *)URL;
+
 - (BOOL)validateUserInterfaceItem:(id <NSValidatedUserInterfaceItem>)anItem;
 
 - (void)dealloc;

--- a/macosx/GVWindowController.m
+++ b/macosx/GVWindowController.m
@@ -43,6 +43,8 @@
 	NSWindow *window = [self window];
 	if (![window isZoomed])
 		[window zoom:self];
+
+	[documentView setDelegate:self];
 }
 
 - (void)graphDocumentDidChange:(NSNotification*)notification
@@ -87,6 +89,13 @@
 - (IBAction)printGraphDocument:(id)sender
 {
 	[documentView printWithInfo:[[self document] printInfo] autoRotate:NO];
+}
+
+- (void)PDFViewWillClickOnLink:(PDFView *)sender withURL:(NSURL *)URL
+{
+	NSURL* baseURL = [[self document] fileURL];
+	NSURL* targetURL = [NSURL URLWithString:[URL absoluteString] relativeToURL:baseURL];
+	[[NSWorkspace sharedWorkspace] openURL:targetURL];
 }
 
 - (BOOL)validateUserInterfaceItem:(id <NSValidatedUserInterfaceItem>)anItem


### PR DESCRIPTION
Let's say we have a file `a.dot` linking another file `b.dot` using relative URL:
```
digraph a {
    "b.dot" [URL="b.dot"];
}
```

Previously, we get the following error message when the node is clicked:
![message](https://cloud.githubusercontent.com/assets/516599/14044825/8131bf74-f262-11e5-8bc8-d4df080605f2.png)
Since it already supports "file://" with absolute paths, I think it makes sense to support the relative ones as well. This patch fixes this error by using the URL of the opened file as a base URL of the target URL.