### PR TITLE
Update splineType grammar in Dot.ref

### DIFF
--- a/doc/Dot.ref
+++ b/doc/Dot.ref
@@ -647,7 +647,7 @@ shape
      shapes : polygon-based, record-based and PostScript-based.
 splineType
      spline ( ';' spline )*
-      where spline= (endp)? (startp)? point (triple)]*
+      where spline= (startp)? (endp)? point (triple)]*
        and triple = point point point
          and endp = "e,%d,%d"
        and startp = "s,%d,%d"


### PR DESCRIPTION
It seems that dot indeed provides the (optional) spline start point before the (optional) spline end point. The documentation however lists them in the inverse order, which should be adjusted.