### PR TITLE
Added dependencies to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ sudo: false
 addons:
   apt:
     packages:
-      - libgd2-xpm-dev
       - ksh
+      - libgd2-xpm-dev
+      - tcl-dev
+      - libdevil-dev
+      - libxaw7-dev
+      - freeglut3-dev
+
 script:
   - ./autogen.sh
   - ./configure


### PR DESCRIPTION
Various optional libraries where not present in Travis, resulting in multiple warnings. To mitigate this, the libraries where added to the .travis.yml file.