### PR TITLE
Small changes in autogen.sh and configure.ac

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -10,12 +10,15 @@ else
             echo "Warning: we do not know how to invoke date correctly." >&2
         fi    
     fi
-    echo "Graphviz version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
+    echo "Graphviz: version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
+
+    GRAPHVIZ_VERSION_COMMIT=$( git log -n 1 --format=%h )
+    echo "Graphviz: abbreviated hash of last commit: $GRAPHVIZ_VERSION_COMMIT"
 fi
 
 # initialize version for a "stable" build
 cat >./version.m4 <<EOF
-dnl graphviz package version number, (as distinct from shared library version)
+dnl Graphviz package version number, (as distinct from shared library version)
 dnl For the minor number: odd => unstable series
 dnl                       even => stable series
 dnl For the micro number: 0 => in-progress development
@@ -26,7 +29,7 @@ dnl NB: the next line gets changed to a date/time string for development release
 m4_define(graphviz_version_micro, $GRAPHVIZ_VERSION_DATE)
 m4_define(graphviz_version_date, $GRAPHVIZ_VERSION_DATE)
 m4_define(graphviz_collection, test)
-m4_define(graphviz_version_commit, unknown)
+m4_define(graphviz_version_commit, $GRAPHVIZ_VERSION_COMMIT)
 EOF
 
 # attempt to suppress ar messages for 'u' when 'D' present.

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,23 +1,16 @@
 #! /bin/sh
 
-GRAPHVIZ_GIT_DATE=$( git log -n 1 --format=%ci )
-
-if test $? -eq 0; then
-    GRAPHVIZ_VERSION_DATE=$( date -u +%Y%m%d.%H%M -d "$GRAPHVIZ_GIT_DATE" 2>/dev/null )
-    if test $? -ne 0; then
-        # try date with FreeBSD syntax
-        GRAPHVIZ_VERSION_DATE=$( date -u -j -f "%Y-%m-%d %H:%M:%S %z" "$GRAPHVIZ_GIT_DATE" +%Y%m%d.%H%M )
-        if test $? -ne 0; then
-            echo "Warning: we do not know how to invoke date correctly." >&2
-        else
-            echo "Version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
-        fi
-    else
-        echo "Version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
-    fi
-else
+if ! GRAPHVIZ_GIT_DATE=$( git log -n 1 --format=%ci ) ; then
     GRAPHVIZ_VERSION_DATE="0"
-    echo "Warning: we do not appear to be running in a git clone." >&2
+    echo "Warning: build not started in a Git clone, or Git is not installed: setting version date to 0." >&2
+else
+    if ! GRAPHVIZ_VERSION_DATE=$( date -u +%Y%m%d.%H%M -d "$GRAPHVIZ_GIT_DATE" 2>/dev/null ) ; then
+        # try date with FreeBSD syntax
+        if ! GRAPHVIZ_VERSION_DATE=$( date -u -j -f "%Y-%m-%d %H:%M:%S %z" "$GRAPHVIZ_GIT_DATE" +%Y%m%d.%H%M ); then
+            echo "Warning: we do not know how to invoke date correctly." >&2
+        fi    
+    fi
+    echo "Graphviz version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
 fi
 
 # initialize version for a "stable" build

--- a/autogen.sh
+++ b/autogen.sh
@@ -28,7 +28,7 @@ m4_define(graphviz_version_minor, 39)
 dnl NB: the next line gets changed to a date/time string for development releases
 m4_define(graphviz_version_micro, $GRAPHVIZ_VERSION_DATE)
 m4_define(graphviz_version_date, $GRAPHVIZ_VERSION_DATE)
-m4_define(graphviz_collection, test)
+m4_define(graphviz_collection, development)
 m4_define(graphviz_version_commit, $GRAPHVIZ_VERSION_COMMIT)
 EOF
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,7 @@ if test $? -eq 0; then
         # try date with FreeBSD syntax
         GRAPHVIZ_VERSION_DATE=$( date -u -j -f "%Y-%m-%d %H:%M:%S %z" "$GRAPHVIZ_GIT_DATE" +%Y%m%d.%H%M )
         if test $? -ne 0; then
-            echo "Warning: we do not know how to invoke date correctly." >$2
+            echo "Warning: we do not know how to invoke date correctly." >&2
         else
             echo "Version date is based on time of last commit: $GRAPHVIZ_VERSION_DATE"
         fi
@@ -17,7 +17,7 @@ if test $? -eq 0; then
     fi
 else
     GRAPHVIZ_VERSION_DATE="0"
-    echo "Warning: we do not appear to be running in a git clone." >$2
+    echo "Warning: we do not appear to be running in a git clone." >&2
 fi
 
 # initialize version for a "stable" build

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@
 # Try to use version available on FC8
 AC_PREREQ(2.61)
 
+dnl ===========================================================================
+dnl Set Graphviz version information
+
 # set:
 #	graphviz_version_major
 #	graphviz_version_minor
@@ -19,13 +22,13 @@ GRAPHVIZ_VERSION_MAJOR=graphviz_version_major()
 GRAPHVIZ_VERSION_MINOR=graphviz_version_minor()
 GRAPHVIZ_VERSION_MICRO=graphviz_version_micro()
 
-#NB: "stable" or "development"
+# NB: "stable" or "development"
 GRAPHVIZ_COLLECTION=graphviz_collection()
 
-#NB: date/time of last commit - or "0"
+# NB: date/time of last commit - or "0"
 GRAPHVIZ_VERSION_DATE=graphviz_version_date()
 
-#NB: git commit hash of last commit
+# NB: git commit hash of last commit
 GRAPHVIZ_VERSION_COMMIT=graphviz_version_commit()
 
 GRAPHVIZ_SOURCES=graphviz/$GRAPHVIZ_COLLECTION/SOURCES


### PR DESCRIPTION
While working on the Appveyor build, I noticed some areas in the build files that could be improved. In this pull request I address a few of these:
- I refactored the `GRAPHVIZ_VERSION_DATE` if statement in autogen.sh. I think the code is more elegant, while keeping the result unchanged.
- `graphviz_version_commit `was set to unkown, it is now set to the abbreviated
hash of last commit.
- `graphviz_collection` is now set to `development` instead of `test`, as configure.ac contains a comments saying it is either `stable` or `development`.
