### PR TITLE
Publishing Linux release to Github with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,36 @@ addons:
       - freeglut3-dev
 
 script:
-  - ./autogen.sh
-  - ./configure
+  - GRAPHVIZ_DESTINATION_FOLDER="graphviz-build"
+
+  # Build and install to non-root folder
+  - ./autogen.sh NOCONFIG
+  - ./configure --prefix=${TRAVIS_BUILD_DIR}/${GRAPHVIZ_DESTINATION_FOLDER}
   - make
+  - make install
+  # List contents of directory to see if the install created the directory succesfully
+  - ls
+  # Show contents of created directory
+  - ls ${GRAPHVIZ_DESTINATION_FOLDER}
+
+  # Add build/bin folder to path so the tests can run
+  - PATH=${TRAVIS_BUILD_DIR}/${GRAPHVIZ_DESTINATION_FOLDER}/bin:$PATH
+  - echo $PATH
+  - dot -V
+  - dot -c
   - make check
+
+before_deploy:
+  # Put package in tar.gz
+  - GRAPHVIZ_PACKAGE_NAME="graphviz-${TRAVIS_TAG}-linux.tar.gz"
+  - tar czf ${GRAPHVIZ_PACKAGE_NAME} ${GRAPHVIZ_DESTINATION_FOLDER}
+
+deploy:
+  provider: releases
+  api_key:
+    secure: yAzN0eQhLmZGRPji7FfjHXrH5vDOc5cmdO1ZvZf0Evu7Z1XArPmf6oZNSImQ9iGpFzeUQd0NnjKWCjD0JZboqmo5jgFpGnEdPzeXy8H0tMJhzaCuEUC6GQ97SwQwywonPcbAaj6Yj1xhbPAeqIHSdTIDx7cxK+FGHLMdr/HHojZXofoLl+s18fMq528OieZqd+TUkRSoovCBsCcSYs+Sezt5zHNUduFbPeAWCzG4Nq1aHMkolrv2//ojsD7Di+8UgWTglGbvlrQWaZWwjFKjmYOGXPho9I0fwTu8fGvCuxX9tY1Muvy1Ho2Ja2yOq3vwyWjeT1rltUtv/jY7hV8GA2YQiPqNhBSuKQHFrG9NNOkWTTQvQGeJYdnuwLWs0hZReZq+8K9rTzGu/RDHA4kSRkC2uOc59K0Ct5mTwrpGv00dm/oefkoUiCnW3dbgsv8Rctbaa3YF+F56IirkopdJU3ojOm6xKFf6NkG3FpOhszsZyRnm4tnW8V3gY/jmtdDSzc/6ZydGVpyxYhbrtc+hH8PFGSfVm7GgTxrQE/+aCsHd4/E5fsdFCPYLGllUdgIyqkxjLjK95p7LbaTD6XRKbGjiITy/Txq5VodfTgpixVYOnRr/D91psB7xT0N150l+Ipp2ijsU6Q6XXqzb3AyZ09aW/yvhNtXy0/BXgkeFHFg=
+  file_glob: true
+  file: ${GRAPHVIZ_PACKAGE_NAME}
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
With this configuration, Travis will build and release the package to Github when a Git tag is pushed. Right now it publishes to my personal fork, as my encrypted api key is used. This should be changed to the Graphviz repository api key as soon as possible. The [Travis documentation](https://docs.travis-ci.com/user/deployment/releases/) explains how to generate secure api keys for Travis easily and I am willing to help.