### PR TITLE
Fix windows build

### DIFF
--- a/cmd/tools/bcomps.vcxproj
+++ b/cmd/tools/bcomps.vcxproj
@@ -40,13 +40,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>

--- a/cmd/tools/gvpack.vcxproj
+++ b/cmd/tools/gvpack.vcxproj
@@ -40,13 +40,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>

--- a/cmd/tools/mm2gv.vcxproj
+++ b/cmd/tools/mm2gv.vcxproj
@@ -40,14 +40,14 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/cmd/tools/sccmap.vcxproj
+++ b/cmd/tools/sccmap.vcxproj
@@ -40,14 +40,14 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/cmd/tools/tred.vcxproj
+++ b/cmd/tools/tred.vcxproj
@@ -40,14 +40,14 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/cmd/tools/unflatten.vcxproj
+++ b/cmd/tools/unflatten.vcxproj
@@ -40,13 +40,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)Debug\Graphviz\bin\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Debug\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)Graphviz\bin\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Release\$(ProjectName)\</IntDir>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>

--- a/plugin/core/gvplugin_core.c
+++ b/plugin/core/gvplugin_core.c
@@ -16,7 +16,9 @@
 extern gvplugin_installed_t gvdevice_dot_types[];
 extern gvplugin_installed_t gvdevice_fig_types[];
 extern gvplugin_installed_t gvdevice_map_types[];
+#if !defined(WIN32)
 extern gvplugin_installed_t gvdevice_mp_types[];
+#endif
 extern gvplugin_installed_t gvdevice_ps_types[];
 extern gvplugin_installed_t gvdevice_svg_types[];
 #if !defined(WIN32)
@@ -30,7 +32,9 @@ extern gvplugin_installed_t gvdevice_pov_types[];
 extern gvplugin_installed_t gvrender_dot_types[];
 extern gvplugin_installed_t gvrender_fig_types[];
 extern gvplugin_installed_t gvrender_map_types[];
+#if !defined(WIN32)
 extern gvplugin_installed_t gvrender_mp_types[];
+#endif
 extern gvplugin_installed_t gvrender_ps_types[];
 extern gvplugin_installed_t gvrender_svg_types[];
 #if !defined(WIN32)
@@ -50,7 +54,9 @@ static gvplugin_api_t apis[] = {
     {API_device, gvdevice_dot_types},
     {API_device, gvdevice_fig_types},
     {API_device, gvdevice_map_types},
+#if !defined(WIN32)
     {API_device, gvdevice_mp_types},
+#endif
     {API_device, gvdevice_ps_types},
     {API_device, gvdevice_svg_types},
 #if !defined(WIN32)
@@ -64,7 +70,9 @@ static gvplugin_api_t apis[] = {
     {API_render, gvrender_dot_types},
     {API_render, gvrender_fig_types},
     {API_render, gvrender_map_types},
+#if !defined(WIN32)
     {API_render, gvrender_mp_types},
+#endif
     {API_render, gvrender_ps_types},
     {API_render, gvrender_svg_types},
 #if !defined(WIN32)

--- a/windows/include/ast_common.h
+++ b/windows/include/ast_common.h
@@ -100,18 +100,18 @@
 #define __DEFINE__(T,obj,val)	T obj = val
 #endif
 #ifndef _AST_STD_H
-#	if defined(_hdr_stddef)
+#	if _hdr_stddef
 #	include	<stddef.h>
 #	endif
-#	if defined(_sys_types)
+#	if _sys_types
 #	include	<sys/types.h>
 #	endif
 #endif
-#if !defined(_typ_size_t)
+#if !_typ_size_t
 #	define _typ_size_t	1
 typedef int size_t;
 #endif
-#if !defined(_typ_ssize_t)
+#if !_typ_ssize_t
 #	define _typ_ssize_t	1
 typedef int ssize_t;
 #endif


### PR DESCRIPTION
- A few misplaced `defined()` in ast_commmon.h in windows/include caused errors for the Windows build. Removing them solved the problem.
- The recently added mp_types also caused errors on Windows, so I disabled it for now on Windows by using `!defined(WIN32)` around the definitions. Not sure what should be done for this to work.
- A few changes in the project files that allow for a parallel build.