### PR TITLE
Enable C99, enable more warnings and solve some warnings.

### DIFF
--- a/ast_common.h.in
+++ b/ast_common.h.in
@@ -81,10 +81,10 @@
 /* */
 
 /* __STD_C indicates that the language is ANSI-C or C++ */
-#if !defined(__STD_C) && __STDC__
+#if !defined(__STD_C) && defined(__STDC__)
 #define __STD_C         1
 #endif
-#if !defined(__STD_C) && (__cplusplus || c_plusplus)
+#if !defined(__STD_C) && (defined(__cplusplus) || defined(c_plusplus))
 #define __STD_C         1
 #endif
 #if !defined(__STD_C) && _proto_stdc
@@ -96,7 +96,7 @@
 
 /* extern symbols must be protected against C++ name mangling */
 #ifndef _BEGIN_EXTERNS_
-#  if __cplusplus || c_plusplus
+#  if defined(__cplusplus) || defined(c_plusplus)
 #    define _BEGIN_EXTERNS_ extern "C" {
 #    define _END_EXTERNS_   }
 #  else
@@ -133,10 +133,10 @@
 
 /* dynamic linked library external scope handling */
 #undef extern
-#if _dll_import && !defined(__EXPORT__) && _DLL_BLD
+#if defined(_dll_import) && !defined(__EXPORT__) && _DLL_BLD
 #define __EXPORT__      __declspec(dllexport)
 #endif
-#if _dll_import && !defined(__IMPORT__)
+#if defined(_dll_import) && !defined(__IMPORT__)
 #define __IMPORT__      __declspec(dllimport)
 #endif
 #if !defined(_astimport)
@@ -147,7 +147,7 @@
 #endif
 #endif /*_astimport*/
 
-#if !_DLL_BLD && _dll_import
+#if !defined(_DLL_BLD) && defined(_dll_import)
 #define __EXTERN__(T,obj)       extern T obj; T* _imp__ ## obj = &obj
 #define __DEFINE__(T,obj,val)   T obj = val; T* _imp__ ## obj = &obj
 #else
@@ -156,16 +156,16 @@
 #endif
 
 #ifndef _AST_STD_H
-#       if _hdr_stddef
+#       if defined(_hdr_stddef)
 #       include <stddef.h>
 #       endif
-#       if _hdr_stdarg
+#       if defined(_hdr_stdarg)
 #       include <stdarg.h>
 #       endif
-#       if _hdr_varargs
+#       if defined(_hdr_varargs)
 #       include <varargs.h>
 #       endif
-#       if _sys_types
+#       if defined(_sys_types)
 #       include <sys/types.h>
 #       endif
 #endif

--- a/cmd/lefty/dot2l/dotparse.y
+++ b/cmd/lefty/dot2l/dotparse.y
@@ -12,7 +12,7 @@
  *************************************************************************/
 
 %{
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include <ast.h>
 #endif
 #include <stdio.h>

--- a/cmd/smyrna/gui/toolboxcallbacks.h
+++ b/cmd/smyrna/gui/toolboxcallbacks.h
@@ -15,7 +15,7 @@
 #define TOOLBOXCALLBACKS_H
 #include <gtk/gtk.h>
 #include "gui.h"
-#if WIN32
+#if defined(WIN32)
 #define _BB  __declspec(dllexport)
 #else
 #define _BB /**/

--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,27 @@ if test "x$TCLSH" = "x"; then
 #  fi
 fi
 
+dnl ===========================================================================
+dnl Set GCC compiler flags
+
+if [test "${GCC}" == "yes"]
+then
+  # Enable c99
+  CFLAGS="${CFLAGS} -std=c99"
+  
+  # When enabling c99 on this codebase, this POSIX version should be defined
+  CFLAGS="${CFLAGS} -D_POSIX_C_SOURCE=200112L"
+  
+  # Enable common warnings flags
+  CFLAGS="${CFLAGS} -Wall"
+  
+  # Enable common extra flags
+  CFLAGS="${CFLAGS} -Wextra"
+  
+  # Enable specific warning flags not included by -Wall or -Wextra
+  CFLAGS="${CFLAGS} -Wdouble-promotion -Wmissing-include-dirs -Wswitch-default -Wtrampolines -Wfloat-equal -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wconversion -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs"
+fi
+
 dnl -----------------------------------
 dnl checks for compilers
 

--- a/lib/agraph/agraph.h
+++ b/lib/agraph/agraph.h
@@ -230,7 +230,7 @@ for the name. */
     };
 
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 /* fine control of object callbacks */
 #   if defined(_BLD_agraph) && defined(__EXPORT__)
 #	define extern  __EXPORT__
@@ -395,7 +395,7 @@ for the name. */
 #define aghead(e)		AGHEAD(e)
 #define agopp(e)		AGOPP(e)
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #   if !defined(_BLD_agraph) && defined(__IMPORT__)
 #	define extern  __IMPORT__
 #   endif
@@ -408,7 +408,7 @@ for the name. */
 	Agstrictundirected;
 
 #undef extern
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
      _END_EXTERNS_
 #endif
 #ifdef __cplusplus

--- a/lib/cdt/cdt.h
+++ b/lib/cdt/cdt.h
@@ -240,7 +240,7 @@ extern int		dtstat _ARG_((Dt_t*, Dtstat_t*, int));
 extern unsigned int	dtstrhash _ARG_((unsigned int, Void_t*, int));
 
 #if 0
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 extern int		memcmp _ARG_((const Void_t*, const Void_t*, size_t));
 extern int		strcmp _ARG_((const char*, const char*));
 #endif

--- a/lib/cdt/cdt.h
+++ b/lib/cdt/cdt.h
@@ -183,10 +183,10 @@ struct _dtstat_s
 #define DT_HASHSIZE	7	/* setting hash table size		*/
 
 _BEGIN_EXTERNS_	/* public data */
-#if _BLD_cdt && defined(__EXPORT__)
+#if defined(_BLD_cdt) && defined(__EXPORT__)
 #define extern	__EXPORT__
 #endif
-#if !_BLD_cdt && defined(__IMPORT__)
+#if !defined(_BLD_cdt) && defined(__IMPORT__)
 #define extern	__IMPORT__
 #endif
 
@@ -215,7 +215,7 @@ extern Dtmethod_t	_Dtstack;
 _END_EXTERNS_
 
 _BEGIN_EXTERNS_	/* public functions */
-#if _BLD_cdt && defined(__EXPORT__)
+#if defined(_BLD_cdt) && defined(__EXPORT__)
 #define extern	__EXPORT__
 #endif
 

--- a/lib/cgraph/cgraph.h
+++ b/lib/cgraph/cgraph.h
@@ -255,7 +255,7 @@ struct Agraph_s {
 };
 
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 /* fine control of object callbacks */
 #   if defined(_BLD_cgraph) && defined(__EXPORT__)
 #	define extern  __EXPORT__
@@ -427,7 +427,7 @@ extern agusererrf agseterrf(agusererrf);
 #define TAILPORT_ID		"tailport"
 #define HEADPORT_ID		"headport"
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #   if !defined(_BLD_cgraph) && defined(__IMPORT__)
 #	define extern  __IMPORT__
 #   endif
@@ -470,7 +470,7 @@ and edges are embedded in main graph objects but allocated separately in subgrap
 #define EDGEOF(sn,rep)		(AGSNMAIN(sn)?((Agedge_t*)((unsigned char*)(rep) - offsetof(Agedge_t,seq_link))) : ((Dthold_t*)(rep))->obj)
 
 #undef extern
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 _END_EXTERNS_
 #endif
 #ifdef __cplusplus

--- a/lib/cgraph/io.c
+++ b/lib/cgraph/io.c
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 #include <cghdr.h>
-#if WIN32
+#if defined(WIN32)
 #include <io.h>
 #endif
 

--- a/lib/cgraph/mem.c
+++ b/lib/cgraph/mem.c
@@ -15,12 +15,12 @@
 
 /* memory management discipline and entry points */
 
-#if (HAVE_AST || HAVE_VMALLOC)
+#if defined(HAVE_AST) || defined(HAVE_VMALLOC)
 
 	/* vmalloc based allocator */
 static void *memopen(void)
 {
-#if DEBUG || MEMDEBUG
+#if defined(DEBUG) || defined(MEMDEBUG)
     return vmopen(Vmdcheap, Vmdebug,
 		  VM_MTDEBUG | VM_DBCHECK | VM_DBABORT | VM_TRACE);
 #else

--- a/lib/graph/graph.h
+++ b/lib/graph/graph.h
@@ -16,7 +16,7 @@
 #ifndef _GRAPH_H
 #define _GRAPH_H 1
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include    <ast.h>
 #else
 #include <sys/types.h>
@@ -122,7 +122,7 @@ extern "C" {
 	Agproto_t *prev;
     };
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
      _BEGIN_EXTERNS_		/* public data */
 #if _BLD_graph && defined(__EXPORT__)
 #define extern  __EXPORT__
@@ -229,7 +229,7 @@ extern "C" {
 #define agmetanode(g)		((g)->meta_node)
 
 #undef extern
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
      _END_EXTERNS_
 #endif
 #ifdef __cplusplus

--- a/lib/graph/libgraph.h
+++ b/lib/graph/libgraph.h
@@ -19,7 +19,7 @@ extern "C" {
 #ifndef _LIBGRAPH_H
 #define _LIBGRAPH_H 1
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include    <ast.h>
 #else
 #include <stdarg.h>

--- a/lib/neatogen/matinv.c
+++ b/lib/neatogen/matinv.c
@@ -34,7 +34,7 @@
  *	n    - the order of the matrices A and Ainv
  */
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include <ast.h>
 #else
 #endif

--- a/lib/pathplan/route.c
+++ b/lib/pathplan/route.c
@@ -352,7 +352,7 @@ static int splinefits(Pedge_t * edges, int edgen, Ppoint_t pa,
 	    growops(opl + 4);
 	    for (pi = 1; pi < 4; pi++)
 		ops[opl].x = sps[pi].x, ops[opl++].y = sps[pi].y;
-#if DEBUG >= 1
+#if defined(DEBUG) && DEBUG >= 1
 	    fprintf(stderr, "success: %f %f\n", a, b);
 #endif
 	    return 1;
@@ -362,7 +362,7 @@ static int splinefits(Pedge_t * edges, int edgen, Ppoint_t pa,
 		growops(opl + 4);
 		for (pi = 1; pi < 4; pi++)
 		    ops[opl].x = sps[pi].x, ops[opl++].y = sps[pi].y;
-#if DEBUG >= 1
+#if defined(DEBUG) && DEBUG >= 1
 		fprintf(stderr, "forced straight line: %f %f\n", a, b);
 #endif
 		return 1;
@@ -374,7 +374,7 @@ static int splinefits(Pedge_t * edges, int edgen, Ppoint_t pa,
 	else
 	    a = b = 0;
     }
-#if DEBUG >= 1
+#if defined(DEBUG) && DEBUG >= 1
     fprintf(stderr, "failure\n");
 #endif
     return 0;

--- a/lib/pathplan/shortest.c
+++ b/lib/pathplan/shortest.c
@@ -162,7 +162,7 @@ int Pshortestpath(Ppoly_t * polyp, Ppoint_t * eps, Ppolyline_t * output)
 	}
     }
 
-#if DEBUG >= 1
+#if defined(DEBUG) && DEBUG >= 1
     fprintf(stderr, "points\n%d\n", pnll);
     for (pnli = 0; pnli < pnll; pnli++)
 	fprintf(stderr, "%f %f\n", pnls[pnli].pp->x, pnls[pnli].pp->y);
@@ -171,7 +171,7 @@ int Pshortestpath(Ppoly_t * polyp, Ppoint_t * eps, Ppolyline_t * output)
     /* generate list of triangles */
     triangulate(pnlps, pnll);
 
-#if DEBUG >= 2
+#if defined(DEBUG) && DEBUG >= 2
     fprintf(stderr, "triangles\n%d\n", tril);
     for (trii = 0; trii < tril; trii++)
 	for (ei = 0; ei < 3; ei++)
@@ -283,7 +283,7 @@ int Pshortestpath(Ppoly_t * polyp, Ppoint_t * eps, Ppolyline_t * output)
 	    }
     }
 
-#if DEBUG >= 1
+#if defined(DEBUG) && DEBUG >= 1
     fprintf(stderr, "polypath");
     for (pnlp = &epnls[1]; pnlp; pnlp = pnlp->link)
 	fprintf(stderr, " %f %f", pnlp->pp->x, pnlp->pp->y);

--- a/lib/sfio/sfcvt.c
+++ b/lib/sfio/sfcvt.c
@@ -45,7 +45,7 @@ int format;			/* conversion format            */
 
     *sign = *decpt = 0;
 
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
     if (format & SFFMT_LDOUBLE) {
 	Sfdouble_t dval = *((Sfdouble_t *) dv);
 

--- a/lib/sfio/sfhdr.h
+++ b/lib/sfio/sfhdr.h
@@ -32,7 +32,7 @@ extern "C" {
 #include	<vthread.h>
 
 /* file system info */
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 
 #include	<ast.h>
 #include	<ast_time.h>
@@ -47,7 +47,7 @@ extern "C" {
 #define _lib_locale	1
 #endif
 
-#else				/*!_PACKAGE_ast */
+#else				/*!defined(_PACKAGE_ast) */
 
 #if __mips == 2 && !defined(_NO_LARGEFILE64_SOURCE)
 #define _NO_LARGEFILE64_SOURCE  1
@@ -143,7 +143,7 @@ extern "C" {
 #include	<unistd.h>
 #endif
 
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 
 #include	<errno.h>
 #include	<ctype.h>
@@ -459,7 +459,7 @@ extern "C" {
 #define ESPIPE	29
 #endif
 /* see if we can use memory mapping for io */
-#if !_PACKAGE_ast && _mmap_worthy
+#if !defined(_PACKAGE_ast) && _mmap_worthy
 #	ifdef _LARGEFILE64_SOURCE
 #		undef	mmap
 #	endif
@@ -823,7 +823,7 @@ extern "C" {
 
 #define	SF_RADIX	64	/* maximum integer conversion base */
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #define SF_MAXINT	INT_MAX
 #define SF_MAXLONG	LONG_MAX
 #else
@@ -928,7 +928,7 @@ extern "C" {
 #define max(x,y)	((x) > (y) ? (x) : (y))
 
 /* fast functions for memory copy and memory clear */
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #define memclear(s,n)	memzero(s,n)
 #else
 #if _lib_bcopy && !_lib_memcpy
@@ -939,7 +939,7 @@ extern "C" {
 #else
 #define memclear(s,n)	memset((s),'\0',(n))
 #endif
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 
 /* note that MEMCPY advances the associated pointers */
 #define MEMCPY(to,fr,n) \
@@ -1000,7 +1000,7 @@ extern "C" {
     extern int munmap _ARG_((Void_t *, size_t));
 #endif
 
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 
 #if /*!__STDC__ &&*/ !_hdr_stdlib
     extern void abort _ARG_((void));
@@ -1089,7 +1089,7 @@ extern "C" {
     extern int open _ARG_((const char *, int, ...));
 #endif
 
-#endif				/* _PACKAGE_ast */
+#endif				/* defined(_PACKAGE_ast) */
 
      _END_EXTERNS_
 #endif /*_SFHDR_H*/

--- a/lib/sfio/sfhdr.h
+++ b/lib/sfio/sfhdr.h
@@ -49,11 +49,12 @@ extern "C" {
 
 #else				/*!defined(_PACKAGE_ast) */
 
-#if __mips == 2 && !defined(_NO_LARGEFILE64_SOURCE)
+#if defined(__mips) && __mips == 2 && !defined(_NO_LARGEFILE64_SOURCE)
 #define _NO_LARGEFILE64_SOURCE  1
 #endif
 #if !defined(_NO_LARGEFILE64_SOURCE) && \
-	_lib_lseek64 && _lib_stat64 && _lib_mmap64 && _typ_off64_t && _typ_struct_stat64
+	_lib_lseek64 && _lib_stat64 && _lib_mmap64 && defined(_typ_off64_t) && \
+	_typ_struct_stat64
 #	if !defined(_LARGEFILE64_SOURCE)
 #	define _LARGEFILE64_SOURCE     1
 #	endif
@@ -64,7 +65,7 @@ extern "C" {
 /* when building the binary compatibility package, a number of header files
    are not needed and they may get in the way so we remove them here.
 */
-#if _SFBINARY_H
+#if defined(_SFBINARY_H)
 #undef  _hdr_time
 #undef  _sys_time
 #undef  _sys_stat
@@ -194,7 +195,7 @@ extern "C" {
 #endif
 #endif /*_lib_select_*/
 
-#if _lib_poll
+#if defined(_lib_poll)
 #include	<poll.h>
 
 #if _lib_poll_fd_1
@@ -219,10 +220,10 @@ extern "C" {
 
 /* alternative process forking */
 #if _lib_vfork && !defined(fork) && !defined(sparc) && !defined(__sparc)
-#if _hdr_vfork
+#if defined(_hdr_vfork)
 #include	<vfork.h>
 #endif
-#if _sys_vfork
+#if defined(_sys_vfork)
 #include	<sys/vfork.h>
 #endif
 #define fork	vfork
@@ -269,7 +270,7 @@ extern "C" {
 #endif
 #endif
 
-#if !defined(SF_MAXDOUBLE) && _hdr_floatingpoint
+#if !defined(SF_MAXDOUBLE) && defined(_hdr_floatingpoint)
 #include	<floatingpoint.h>
 #if !defined(SF_MAXDOUBLE) && defined(MAXDOUBLE)
 #define SF_MAXDOUBLE	MAXDOUBLE
@@ -289,13 +290,13 @@ extern "C" {
 #endif
 #endif
 
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 
 #if !defined(SF_MAXDOUBLE)
 #define SF_MAXDOUBLE	1.79769313486231570e+308
 #endif
 
-#if _lib_qfrexp && _lib_qldexp
+#if defined(_lib_qfrexp) && _lib_qldexp
 #define _has_expfuncs	1
 #define frexp		qfrexp
 #define ldexp		qldexp
@@ -459,7 +460,7 @@ extern "C" {
 #define ESPIPE	29
 #endif
 /* see if we can use memory mapping for io */
-#if !defined(_PACKAGE_ast) && _mmap_worthy
+#if !defined(_PACKAGE_ast) && defined(_mmap_worthy)
 #	ifdef _LARGEFILE64_SOURCE
 #		undef	mmap
 #	endif
@@ -677,7 +678,7 @@ extern "C" {
 #define SF_NMAP		8
 
 /* set/unset sequential states for mmap */
-#if _lib_madvise && defined(MADV_SEQUENTIAL) && defined(MADV_NORMAL)
+#if defined(_lib_madvise) && defined(MADV_SEQUENTIAL) && defined(MADV_NORMAL)
 #define SFMMSEQON(f,a,s)	(void)(madvise((caddr_t)(a),(size_t)(s),MADV_SEQUENTIAL) )
 #define SFMMSEQOFF(f,a,s)	(void)(madvise((caddr_t)(a),(size_t)(s),MADV_NORMAL) )
 #else
@@ -836,7 +837,7 @@ extern "C" {
 /* floating point to ascii conversion */
 #define SF_MAXEXP10	6
 #define SF_MAXPOW10	(1 << SF_MAXEXP10)
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 #define SF_FDIGITS	1024	/* max allowed fractional digits */
 #define SF_IDIGITS	(8*1024)	/* max number of digits in int part */
 #else
@@ -995,7 +996,7 @@ extern "C" {
 #endif
 #endif
 
-#if !_hdr_mman && !_sys_mman
+#if !defined(_hdr_mman) && !_sys_mman
     extern Void_t *mmap _ARG_((Void_t *, size_t, int, int, int, off_t));
     extern int munmap _ARG_((Void_t *, size_t));
 #endif
@@ -1073,11 +1074,11 @@ extern "C" {
     extern int fstat _ARG_((int, Stat_t *));
 #endif
 
-#if _lib_vfork && !_hdr_vfork && !_sys_vfork
+#if _lib_vfork && !defined(_hdr_vfork) && !defined(_sys_vfork)
     extern pid_t vfork _ARG_((void));
 #endif /*_lib_vfork*/
 
-#if _lib_poll
+#if defined(_lib_poll)
 #if _lib_poll_fd_1
     extern int poll _ARG_((struct pollfd *, ulong, int));
 #else
@@ -1085,7 +1086,7 @@ extern "C" {
 #endif
 #endif /*_lib_poll*/
 
-#if _proto_open && __cplusplus
+#if _proto_open && defined(__cplusplus)
     extern int open _ARG_((const char *, int, ...));
 #endif
 

--- a/lib/sfio/sfio.h
+++ b/lib/sfio/sfio.h
@@ -214,7 +214,7 @@ extern "C" {
 #define SF_STRING	0000004	/* a string stream                      */
 
 #define SF_APPENDWR	0000010	/* file is in append mode only.         */
-#if !_mac_SF_APPEND
+#if defined(_mac_SF_APPEND) && !_mac_SF_APPEND
 #define SF_APPEND	SF_APPENDWR	/* this was the original append bit */
     /* but BSDI stat.h now uses this symbol. */
     /* So we leave it out in such cases.    */
@@ -246,7 +246,7 @@ extern "C" {
 #define SF_SEEK		3	/* seek error                           */
 
 #define SF_CLOSING	4	/* stream is about to be closed.        */
-#if !_mac_SF_CLOSE
+#if defined(_mac_SF_CLOSE) && !_mac_SF_CLOSE
 #define SF_CLOSE	SF_CLOSING	/* this was the original close event */
     /* but AIX now uses this symbol. So we  */
     /* avoid defining it in such cases.     */
@@ -277,7 +277,7 @@ extern "C" {
 
      _BEGIN_EXTERNS_ extern ssize_t _Sfi;
 
-#if _BLD_sfio && defined(GVDLL)
+#if defined(_BLD_sfio) && defined(GVDLL)
 #define extern	__declspec(dllexport)
 #endif
 /* standard in/out/err streams */
@@ -289,7 +289,7 @@ extern "C" {
     extern Sfio_t _Sfstderr;
 #undef extern
 
-#if _DLL && _DLL_INDIRECT_DATA
+#if defined(_DLL) && defined(_DLL_INDIRECT_DATA)
 /* The Uwin shared library environment requires these to be defined
    in a global structure set up by the Uwin start-up procedure.
 */
@@ -298,7 +298,7 @@ extern "C" {
 #define sfstderr	((Sfio_t*)_ast_dll->_ast_stderr)
 #endif
 
-#if _BLD_sfio && defined(__EXPORT__)
+#if defined(_BLD_sfio) && defined(__EXPORT__)
 #define extern	__EXPORT__
 #endif
 
@@ -403,7 +403,7 @@ extern "C" {
 #define SF_U2		(SF_U1*SF_U1)
 #define SF_U3		(SF_U2*SF_U1)
 #define SF_U4		(SF_U3*SF_U1)
-#if __cplusplus
+#if defined(__cplusplus)
 #define _SF_(f)		(f)
 #else
 #define _SF_(f)		((Sfio_t*)(f))
@@ -428,7 +428,7 @@ extern "C" {
 #define __sf_stacked(f)	((f) ? (_SF_(f)->push != (Sfio_t*)0) : 0)
 #define __sf_value(f)	((f) ? (_SF_(f)->val) : 0)
 #define __sf_slen()	(_Sfi)
-#if defined(__INLINE__) && !_BLD_sfio
+#if defined(__INLINE__) && !defined(_BLD_sfio)
      __INLINE__ int sfputd(Sfio_t * f, Sfdouble_t v) {
 	return __sf_putd(f, v);
     } __INLINE__ int sfputl(Sfio_t * f, Sflong_t v) {

--- a/lib/sfio/sfio.h
+++ b/lib/sfio/sfio.h
@@ -25,7 +25,7 @@ extern "C" {
 **	Written by Kiem-Phong Vo
 */
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include	<ast_std.h>
 #else
 #include	<ast_common.h>
@@ -93,7 +93,7 @@ extern "C" {
 #endif
 #endif
 
-#endif				/* _PACKAGE_ast */
+#endif				/* defined(_PACKAGE_ast) */
 
 /* Sfoff_t should be large enough for largest file address */
 

--- a/lib/sfio/sfmode.c
+++ b/lib/sfio/sfmode.c
@@ -34,7 +34,7 @@ static char *Version = "\n@(#)sfio (AT&T Labs - kpv) 2001-02-01\0\n";
 */
 
 /* the below is for protecting the application from SIGPIPE */
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include		<sig.h>
 #include		<wait.h>
 #define Sfsignal_f	Sig_handler_t
@@ -257,7 +257,7 @@ reg Sfio_t *f;			/* stream to close */
 	    CLOSE(p->file);
 
 	/* wait for process termination */
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 	sigcritical(1);
 #endif
 #ifndef WIN32
@@ -266,7 +266,7 @@ reg Sfio_t *f;			/* stream to close */
 #endif
 	if (pid < 0)
 	    status = -1;
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 	sigcritical(0);
 #endif
 

--- a/lib/sfio/sfpkrd.c
+++ b/lib/sfio/sfpkrd.c
@@ -12,7 +12,7 @@
  *************************************************************************/
 
 #include	"sfhdr.h"
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 #ifndef FIONREAD
 #if _sys_ioctl
 #include	<sys/ioctl.h>

--- a/lib/sfio/sfpopen.c
+++ b/lib/sfio/sfpopen.c
@@ -17,7 +17,7 @@
 **	Written by Kiem-Phong Vo.
 */
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include	<proc.h>
 #else
 
@@ -123,7 +123,7 @@ char *argcmd;
     _exit(EXIT_NOTFOUND);
 }
 
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 
 #ifndef WIN32
 #if __STD_C
@@ -135,7 +135,7 @@ char *command;			/* command to execute */
 char *mode;			/* mode of the stream */
 #endif
 {
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
     reg Proc_t *proc;
     reg int sflags;
     reg long flags;
@@ -292,6 +292,6 @@ char *mode;			/* mode of the stream */
 	}
 	return NIL(Sfio_t *);
     }
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 }
 #endif

--- a/lib/sfio/sfputd.c
+++ b/lib/sfio/sfputd.c
@@ -46,7 +46,7 @@ Sfdouble_t v;
     } else
 	n = 0;
 
-#if !_ast_fltmax_double		/* don't know how to do these yet */
+#if !defined(_ast_fltmax_double)		/* don't know how to do these yet */
     if (v > SF_MAXDOUBLE && !_has_expfuncs) {
 	SFOPEN(f, 0);
 	SFMTXRETURN(f, -1);

--- a/lib/sfio/sftable.c
+++ b/lib/sfio/sftable.c
@@ -378,7 +378,7 @@ int type;
 			fp[n].argv.i = va_arg(args, int);
 		    break;
 		case SFFMT_FLOAT:
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		    if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 			fp[n].argv.ld = va_arg(args, Sfdouble_t);
 		    else

--- a/lib/sfio/sftmp.c
+++ b/lib/sfio/sftmp.c
@@ -140,7 +140,7 @@ char *file;
     return 0;
 }
 
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 #include	<time.h>
 #define		TMPDFLT		"/tmp"
 static char **Tmppath, **Tmpcur;
@@ -190,7 +190,7 @@ char *path;
     return dirs;
 }
 
-#endif				/*!_PACKAGE_ast */
+#endif				/*!defined(_PACKAGE_ast) */
 
 #if __STD_C
 static int _tmpfd(Sfio_t * f)
@@ -203,7 +203,7 @@ Sfio_t *f;
     reg int fd;
     int t;
 
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
     /* set up path of dirs to create temp files */
     if (!Tmppath && !(Tmppath = _sfgetpath("TMPPATH"))) {
 	if (!(Tmppath = (char **) malloc(2 * sizeof(char *))))
@@ -224,12 +224,12 @@ Sfio_t *f;
 	Tmpcur += 1;
     if (!Tmpcur || !Tmpcur[0])
 	Tmpcur = Tmppath;
-#endif				/*!_PACKAGE_ast */
+#endif				/*!defined(_PACKAGE_ast) */
 
     file = NIL(char *);
     fd = -1;
     for (t = 0; t < 10; ++t) {	/* compute a random name */
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 	static ulong Key, A;
 	if (A == 0 || t > 0) {	/* get a quasi-random coefficient */
 	    reg int r;
@@ -246,7 +246,7 @@ Sfio_t *f;
 			Tmpcur[0], (Key >> 15) & 0x7fff, Key & 0x7fff);
 #else
 	file = pathtmp(file, NiL, "sf", NiL);
-#endif				/*!_PACKAGE_ast */
+#endif				/*!defined(_PACKAGE_ast) */
 
 	if (!file)
 	    return -1;
@@ -273,9 +273,9 @@ Sfio_t *f;
 
     if (fd >= 0)
 	_rmtmp(f, file);
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
     free(file);
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 
     return fd;
 }

--- a/lib/sfio/sfvprintf.c
+++ b/lib/sfio/sfvprintf.c
@@ -42,7 +42,7 @@ va_list args;			/* arg list if !argf    */
     int sign, decpt;
     ssize_t size;
     double dval;
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
     Sfdouble_t ldval;
 #endif
     char *tls[2], **ls;		/* for %..[separ]s              */
@@ -434,7 +434,7 @@ va_list args;			/* arg list if !argf    */
 		    argv.i = va_arg(args, int);
 		break;
 	    case SFFMT_FLOAT:
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 		    argv.ld = va_arg(args, Sfdouble_t);
 		else
@@ -786,7 +786,7 @@ va_list args;			/* arg list if !argf    */
 	case 'e':
 	case 'E':
 	case 'f':
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 	    if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 		ldval = argv.ld;
 	    else
@@ -799,7 +799,7 @@ va_list args;			/* arg list if !argf    */
 
 	    if (fmt == 'e' || fmt == 'E') {
 		n = (precis = precis < 0 ? FPRECIS : precis) + 1;
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		if (FMTCMP(size, Sfdouble_t, Sfdouble_t)) {
 		    ep = _sfcvt(&ldval, min(n, SF_FDIGITS),
 				&decpt, &sign,
@@ -813,7 +813,7 @@ va_list args;			/* arg list if !argf    */
 		goto e_format;
 	    } else if (fmt == 'f' || fmt == 'F') {
 		precis = precis < 0 ? FPRECIS : precis;
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		if (FMTCMP(size, Sfdouble_t, Sfdouble_t)) {
 		    ep = _sfcvt(&ldval, min(precis, SF_FDIGITS),
 				&decpt, &sign, SFFMT_LDOUBLE);
@@ -828,7 +828,7 @@ va_list args;			/* arg list if !argf    */
 
 	    /* 'g' or 'G' format */
 	    precis = precis < 0 ? FPRECIS : precis == 0 ? 1 : precis;
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 	    if (FMTCMP(size, Sfdouble_t, Sfdouble_t)) {
 		ep = _sfcvt(&ldval, min(precis, SF_FDIGITS),
 			    &decpt, &sign, SFFMT_EFORMAT | SFFMT_LDOUBLE);
@@ -879,7 +879,7 @@ va_list args;			/* arg list if !argf    */
 
 	    /* build the exponent */
 	    ep = endep = buf + (sizeof(buf) - 1);
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 	    if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 		dval = ldval ? 1. : 0.;	/* so the below test works */
 #endif

--- a/lib/sfio/sfvscanf.c
+++ b/lib/sfio/sfvscanf.c
@@ -549,7 +549,7 @@ va_list args;
 
 	    if (value) {
 		*val = '\0';
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 		    argv.ld = _sfstrtod(accept, NIL(char **));
 		else
@@ -559,7 +559,7 @@ va_list args;
 
 	    if (value) {
 		n_assign += 1;
-#if !_ast_fltmax_double
+#if !defined(_ast_fltmax_double)
 		if (FMTCMP(size, Sfdouble_t, Sfdouble_t))
 		    *((Sfdouble_t *) value) = argv.ld;
 		else

--- a/lib/sfio/vthread.h
+++ b/lib/sfio/vthread.h
@@ -31,7 +31,7 @@ extern "C" {
 #include	<errno.h>
 
 /* ast doesn't do threads yet */
-#if _PACKAGE_ast && !defined(vt_threaded)
+#if defined(_PACKAGE_ast) && !defined(vt_threaded)
 #define vt_threaded     0
 #endif
 

--- a/lib/sfio/vthread.h
+++ b/lib/sfio/vthread.h
@@ -44,7 +44,7 @@ extern "C" {
 #undef vt_threaded
 #undef _may_use_threads	
 
-#if _may_use_threads && !defined(vt_threaded) && _hdr_pthread
+#if defined(_may_use_threads) && !defined(vt_threaded) && defined(_hdr_pthread)
 #define vt_threaded		1
 #include			<pthread.h>
     typedef pthread_mutex_t _vtmtx_t;
@@ -59,7 +59,7 @@ extern "C" {
 
 #endif
 
-#if _may_use_threads && !defined(vt_threaded) && _WIN32
+#if defined(_may_use_threads) && !defined(vt_threaded) && defined(_WIN32)
 #define vt_threaded		1
 #include			<windows.h>
     typedef CRITICAL_SECTION _vtmtx_t;
@@ -123,7 +123,7 @@ extern "C" {
     extern int vtonceerror _ARG_((Vtonce_t *));
 
      _END_EXTERNS_
-#if vt_threaded
+#if defined(vt_threaded) && vt_threaded
 /* mutex structure */
 	struct _vtmutex_s {
 	_vtmtx_t lock;
@@ -151,7 +151,7 @@ extern "C" {
 	int error;
     };
 
-#if _WIN32
+#if defined(_WIN32)
 #define VTONCE_INITDATA		{0, 0}
 #else
 #define VTONCE_INITDATA		{0, PTHREAD_ONCE_INIT }
@@ -165,7 +165,7 @@ extern "C" {
 #endif				/*vt_threaded */
 
 /* fake structures and functions */
-#if !vt_threaded
+#if defined(vt_threaded) && !vt_threaded
     struct _vtmutex_s {
 	int error;
     };

--- a/lib/vmalloc/malloc.c
+++ b/lib/vmalloc/malloc.c
@@ -159,7 +159,7 @@ char *file;
     }
 
     *next = '\0';
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
     return open(buf, O_WRONLY | O_CREAT | O_TRUNC, CREAT_MODE);
 #else
     return creat(buf, CREAT_MODE);

--- a/lib/vmalloc/vmalloc.h
+++ b/lib/vmalloc/vmalloc.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #define VMALLOC_VERSION	19990805L
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 #include	<ast_std.h>
 #else
 #include	<ast_common.h>

--- a/lib/vmalloc/vmexit.c
+++ b/lib/vmalloc/vmexit.c
@@ -17,7 +17,7 @@
 **	Any required functions for process exiting.
 **	Written by Kiem-Phong Vo, kpv@research.att.com (05/25/93).
 */
-#if _PACKAGE_ast || _lib_atexit
+#if defined(_PACKAGE_ast) || _lib_atexit
 int Vm_atexit_already_defined;
 #else
 

--- a/lib/vmalloc/vmhdr.h
+++ b/lib/vmalloc/vmhdr.h
@@ -481,7 +481,7 @@ extern "C" {
 #if !_typ_ssize_t
     typedef int ssize_t;
 #endif
-#if !_WIN32
+#if !defined(_WIN32)
     extern Vmuchar_t *sbrk _ARG_((ssize_t));
 #endif
 

--- a/lib/vmalloc/vmhdr.h
+++ b/lib/vmalloc/vmhdr.h
@@ -30,7 +30,7 @@ extern "C" {
 */
 
 
-#if _PACKAGE_ast
+#if defined(_PACKAGE_ast)
 
 #if defined(__STDPP__directive) && defined(__STDPP__hide)
     __STDPP__directive pragma pp:hide getpagesize
@@ -51,7 +51,7 @@ extern "C" {
 #include	<ast_common.h>
 #include	"FEATURE/vmalloc"
 
-#endif /*_PACKAGE_ast*/
+#endif /*defined(_PACKAGE_ast)*/
 
 #undef free
 #undef malloc
@@ -435,7 +435,7 @@ extern "C" {
      _BEGIN_EXTERNS_ extern Vmextern_t _Vmextern;
 
 
-#if !_PACKAGE_ast
+#if !defined(_PACKAGE_ast)
 
     extern size_t getpagesize _ARG_((void));
 


### PR DESCRIPTION
As discussed in #1139, using C99 enables the use of some newer language features that allow more elegant and more readable code. All major compiler support this standard, even Microsoft's MSVC compiler.
Using C99 results in more compiler warnings when using GCC, because more warnings are enabled by default. Compiler warnings are a good thing and they help to increase the quality of the code, so I created a set of compiler warnings and added this to the the `CFLAGS` in configure.ac. I included a check to only use this configuration when using GCC, because that is the only compiler I tested with and the configure script checks for more compilers.
Using these warning flags, around 14000 warning were generated. This PR also includes some changes that solves around 5500 of those, so about 8500 warnings remain.