### PR TITLE
Improve Travis + deploy make dist results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,13 @@ script:
 - make dist
 
 before_deploy:
-- GRAPHVIZ_PACKAGE_NAME="graphviz-${TRAVIS_TAG}-linux.tar.gz"
-- tar czf ${GRAPHVIZ_PACKAGE_NAME} ${GRAPHVIZ_DESTINATION_FOLDER}
+- export DEPLOYED_FILE=$(ls *.tar.gz)
+- echo "deploying ${DEPLOYED_FILE} to GitHub releases"
 deploy:
   provider: releases
   api_key:
     secure: EmdyQU0yNlq2mYtCz4xRj1Eyd73s5xYcD5tP+E42QmQhCoTSD0nb7J6H9MlzAXby2lgqDxcINvkXuEWGyySi4QHs32H7THbKs0U/dD7FuC7zFIfd2o/Q0kWyASTm8hPwu/OghmitmBXy37+QdfO4Snzy+AqVmHH3VtUax3kf0+qg12fQiNsDRXFJfO9mBddKNjxktjmfdN87pNfcVcNkCZz5DDs91ldIr6FiC+YMbfedtXqEjkavYSpFU/IX6/GJ9suJseGNH7+hmlSfw9yZT5TNd/8dnmUr2j4cD6pKgZWBQfWE/GmoJbYFbfIYfFzkwvLm3OEbr0rnsNabvKmApGpr8XBiO+w1raEXHXLsblp7eQi2BdQFu2QmVhh6vQP0uqAM12oEoC+m2FtR5WVy43RHA4tvK4hddikfUcRDRFQov9rqXj6x/cdmEhuimjugTbzmekrZ9RITucOs6YLtLry05oUjED1AD47rknTJAmZ3W93LANY7CLt8JsLhAODCZO/lTRhrXGOE2mSEiq/fqw2ZPrDPjI8J2BysYO7xb+IW1/S3seOnzL0m2Ox0wZkvDZyg9+HfjIa8AcCdJZ7EXlfDL+ExXcSbGTzwWhvy48f249cSjKM96q0SmVcIyCEapgFSIOyLSYQv3i/+5PB/ZLVT2rOdvj6zPVymAhAxEX4=
-#  file: ''
+  skip_cleanup: true
+  file: "${DEPLOYED_FILE}"
   on:
     repo: ellson/graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,14 @@ install:
 
 script:
 - cd ${TRAVIS_BUILD_DIR}
-- GRAPHVIZ_DESTINATION_FOLDER="graphviz-build"
-- "./autogen.sh NOCONFIG"
-- "./configure --prefix=${TRAVIS_BUILD_DIR}/${GRAPHVIZ_DESTINATION_FOLDER}"
-- make dist
+# Build and test code
+- ./autogen.sh
 - make
-- make install
-- ls
-- ls ${GRAPHVIZ_DESTINATION_FOLDER}
-- PATH=${TRAVIS_BUILD_DIR}/${GRAPHVIZ_DESTINATION_FOLDER}/bin:$PATH
-- echo $PATH
-- dot -V
-- dot -c
+- sudo make install
 - make check
+# Create source package to deploy
+- make dist
+
 before_deploy:
 - GRAPHVIZ_PACKAGE_NAME="graphviz-${TRAVIS_TAG}-linux.tar.gz"
 - tar czf ${GRAPHVIZ_PACKAGE_NAME} ${GRAPHVIZ_DESTINATION_FOLDER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ addons:
     - libdevil-dev
     - libxaw7-dev
     - freeglut3-dev
+    - colorgcc
 
 install:
+# Enable colored gcc output
+- export CC=colorgcc
 # Install unit testing framework Criterion.
 - cd dependencies/criterion
 - mkdir build


### PR DESCRIPTION
Because the results of `make install` when using a prefix aren't binaries suitable to be released, some build steps could either be removed or simplified. Also added colorgcc to Travis to increase readability of the build log.
Every commit will still result in a new untagged release on Github, but the results of `make dist` will now be attached to these releases. The [Neovim project](https://github.com/neovim/neovim) has a script they use to create nightly releases on every successful build, that aren't untagged releases and only keeps the most recent version. The script can be found [here](https://github.com/neovim/bot-ci/blob/master/ci/nightly.sh). We might be able to incorporate this into our own Travis configuration.