### PR TITLE
fix typo TB->BT in docs:shapes

### DIFF
--- a/doc/info/shapes.html
+++ b/doc/info/shapes.html
@@ -330,7 +330,7 @@ from top to bottom and "A | { B | C } | D" will have "B" over "C", with
 <P> 
 The initial orientation of a record node depends on the
 <A HREF="attrs.html#d:rankdir">rankdir</A> attribute. If this attribute
-is <TT>TB</TT> (the default) or <TT>TB</TT>, corresponding to vertical
+is <TT>TB</TT> (the default) or <TT>BT</TT>, corresponding to vertical
 layouts, the top-level fields in a record are displayed horizontally.
 If, however, this attribute is <TT>LR</TT> or <TT>RL</TT>, 
 corresponding to horizontal layouts, the top-level fields are 


### PR DESCRIPTION
```graphviz
digraph G {
rankdir=BT
a--b
}
```

```graphviz
digraph G {
rankdir=BT
a--b
}
```
