### PR TITLE
Resolve some conversion warnings

### DIFF
--- a/lib/cgraph/agxbuf.c
+++ b/lib/cgraph/agxbuf.c
@@ -43,16 +43,16 @@ void agxbinit(agxbuf * xb, unsigned int hint, unsigned char *init)
  */
 int agxbmore(agxbuf * xb, size_t ssz)
 {
-    size_t cnt;			/* current no. of characters in buffer */
-    size_t size;		/* current buffer size */
-    size_t nsize;		/* new buffer size */
-    unsigned char *nbuf;	/* new buffer */
+    size_t cnt = 0;         /* current no. of characters in buffer */
+    size_t size = 0;        /* current buffer size */
+    size_t nsize = 0;       /* new buffer size */
+    unsigned char *nbuf;    /* new buffer */
 
-    size = xb->eptr - xb->buf;
+    size = (size_t) (xb->eptr - xb->buf);
     nsize = 2 * size;
-    if (size + (int)ssz > nsize)
+    if (size + ssz > nsize)
 	nsize = size + ssz;
-    cnt = xb->ptr - xb->buf;
+    cnt = (size_t) (xb->ptr - xb->buf);
     if (xb->dyna) {
 	nbuf = realloc(xb->buf, nsize);
     } else {

--- a/lib/cgraph/attr.c
+++ b/lib/cgraph/attr.c
@@ -193,7 +193,7 @@ static Agrec_t *agmakeattrs(Agraph_t * context, void *obj)
 	sz = topdictsize(obj);
 	if (sz < MINATTR)
 	    sz = MINATTR;
-	rec->str = agalloc(agraphof(obj), sz * sizeof(char *));
+	rec->str = agalloc(agraphof(obj), (size_t) sz * sizeof(char *));
 	/* doesn't call agxset() so no obj-modified callbacks occur */
 	for (sym = (Agsym_t *) dtfirst(datadict); sym;
 	     sym = (Agsym_t *) dtnext(datadict, sym))

--- a/lib/cgraph/grammar.y
+++ b/lib/cgraph/grammar.y
@@ -452,7 +452,7 @@ concat (char* s1, char* s2)
   char*  s;
   char   buf[BUFSIZ];
   char*  sym;
-  int    len = strlen(s1) + strlen(s2) + 1;
+  size_t len = strlen(s1) + strlen(s2) + 1;
 
   if (len <= BUFSIZ) sym = buf;
   else sym = (char*)malloc(len);
@@ -473,7 +473,7 @@ concatPort (char* s1, char* s2)
   char*  s;
   char   buf[BUFSIZ];
   char*  sym;
-  int    len = strlen(s1) + strlen(s2) + 2;  /* one more for ':' */
+  size_t len = strlen(s1) + strlen(s2) + 2;  /* one more for ':' */
 
   if (len <= BUFSIZ) sym = buf;
   else sym = (char*)malloc(len);

--- a/lib/cgraph/rec.c
+++ b/lib/cgraph/rec.c
@@ -94,7 +94,7 @@ void *agbindrec(void *arg_obj, char *recname, unsigned int recsize,
     g = agraphof(obj);
     rec = aggetrec(obj, recname, FALSE);
     if ((rec == NIL(Agrec_t *)) && (recsize > 0)) {
-	rec = (Agrec_t *) agalloc(g, (int) recsize);
+	rec = (Agrec_t *) agalloc(g, recsize);
 	rec->name = agstrdup(g, recname);
 	switch (obj->tag.objtype) {
 	case AGRAPH:
@@ -200,11 +200,18 @@ void aginit(Agraph_t * g, int kind, char *rec_name, int arg_rec_size, int mtf)
     Agnode_t *n;
     Agedge_t *e;
     Agraph_t *s;
-	int		 rec_size;
-	int		 recur;	/* if recursive on subgraphs */
+    unsigned int rec_size;
+    int recur; /* if recursive on subgraphs */
 
-	if (arg_rec_size < 0) {recur = 1; rec_size = -arg_rec_size;}
-	else {recur = 0; rec_size= arg_rec_size;}
+    if (arg_rec_size < 0)
+    {
+        recur = 1;
+    }
+    else
+    {
+        recur = 0;
+    }
+    rec_size = (unsigned int) abs(arg_rec_size);
     switch (kind) {
     case AGRAPH:
 	agbindrec(g, rec_name, rec_size, mtf);

--- a/lib/common/arrows.c
+++ b/lib/common/arrows.c
@@ -138,7 +138,7 @@ static arrowtype_t Arrowtypes[] = {
 static char *arrow_match_name_frag(char *name, arrowname_t * arrownames, int *flag)
 {
     arrowname_t *arrowname;
-    int namelen = 0;
+    size_t namelen = 0;
     char *rest = name;
 
     for (arrowname = arrownames; arrowname->name; arrowname++) {

--- a/lib/common/colxlate.c
+++ b/lib/common/colxlate.c
@@ -145,9 +145,9 @@ static int colorcmpf(const void *p0, const void *p1)
 char *canontoken(char *str)
 {
     static unsigned char *canon;
-    static int allocated;
+    static size_t allocated;
     unsigned char c, *p, *q;
-    int len;
+    size_t len;
 
     p = (unsigned char *) str;
     len = strlen(str);
@@ -162,7 +162,7 @@ char *canontoken(char *str)
 	/* if (isalnum(c) == FALSE) */
 	    /* continue; */
 	if (isupper(c))
-	    c = tolower(c);
+	    c = (unsigned char) tolower(c);
 	*q++ = c;
     }
     *q = '\0';
@@ -175,8 +175,8 @@ char *canontoken(char *str)
 static char* fullColor (char* prefix, char* str)
 {
     static char *fulls;
-    static int allocated;
-    int len = strlen (prefix) + strlen (str) + 3;
+    static size_t allocated;
+    size_t len = strlen(prefix) + strlen(str) + 3;
 
     if (len >= allocated) {
 	allocated = len + 10;
@@ -255,14 +255,15 @@ int colorxlate(char *str, gvcolor_t * color, color_type_t target_type)
 {
     static hsvrgbacolor_t *last;
     static unsigned char *canon;
-    static int allocated;
+    static size_t allocated;
     unsigned char *p, *q;
     hsvrgbacolor_t fake;
     unsigned char c;
     double H, S, V, A, R, G, B;
     double C, M, Y, K;
     unsigned int r, g, b, a;
-    int len, rc;
+    size_t len;
+    int rc;
 
     color->type = target_type;
 

--- a/lib/common/htmllex.c
+++ b/lib/common/htmllex.c
@@ -174,7 +174,7 @@ static int stylefn(htmldata_t * p, char *v)
     char* tk;
     char* buf = strdup (v);
     for (tk = strtok (buf, DELIM); tk; tk = strtok (NULL, DELIM)) {
-	c = toupper(*tk);
+	c = (char) toupper(*tk);
 	if (c == 'R') {
 	    if (!strcasecmp(tk + 1, "OUNDED")) p->style |= ROUNDED;
 	    else if (!strcasecmp(tk + 1, "ADIAL")) p->style |= RADIAL;
@@ -313,7 +313,7 @@ static int rowsfn(htmltbl_t * p, char *v)
 static int fixedsizefn(htmldata_t * p, char *v)
 {
     int rv = 0;
-    char c = toupper(*(unsigned char *) v);
+    char c = (char) toupper(*(unsigned char *) v);
     if ((c == 'T') && !strcasecmp(v + 1, "RUE"))
 	p->flags |= FIXED_FLAG;
     else if ((c != 'F') || strcasecmp(v + 1, "ALSE")) {
@@ -326,7 +326,7 @@ static int fixedsizefn(htmldata_t * p, char *v)
 static int valignfn(htmldata_t * p, char *v)
 {
     int rv = 0;
-    char c = toupper(*v);
+    char c = (char) toupper(*v);
     if ((c == 'B') && !strcasecmp(v + 1, "OTTOM"))
 	p->flags |= VALIGN_BOTTOM;
     else if ((c == 'T') && !strcasecmp(v + 1, "OP"))
@@ -341,7 +341,7 @@ static int valignfn(htmldata_t * p, char *v)
 static int halignfn(htmldata_t * p, char *v)
 {
     int rv = 0;
-    char c = toupper(*v);
+    char c = (char) toupper(*v);
     if ((c == 'L') && !strcasecmp(v + 1, "EFT"))
 	p->flags |= HALIGN_LEFT;
     else if ((c == 'R') && !strcasecmp(v + 1, "IGHT"))
@@ -356,7 +356,7 @@ static int halignfn(htmldata_t * p, char *v)
 static int cell_halignfn(htmldata_t * p, char *v)
 {
     int rv = 0;
-    char c = toupper(*v);
+    char c = (char) toupper(*v);
     if ((c == 'L') && !strcasecmp(v + 1, "EFT"))
 	p->flags |= HALIGN_LEFT;
     else if ((c == 'R') && !strcasecmp(v + 1, "IGHT"))
@@ -373,7 +373,7 @@ static int cell_halignfn(htmldata_t * p, char *v)
 static int balignfn(htmldata_t * p, char *v)
 {
     int rv = 0;
-    char c = toupper(*v);
+    char c = (char) toupper(*v);
     if ((c == 'L') && !strcasecmp(v + 1, "EFT"))
 	p->flags |= BALIGN_LEFT;
     else if ((c == 'R') && !strcasecmp(v + 1, "IGHT"))
@@ -470,7 +470,7 @@ static int scalefn(htmlimg_t * p, char *v)
 static int alignfn(int *p, char *v)
 {
     int rv = 0;
-    char c = toupper(*v);
+    char c = (char) toupper(*v);
     if ((c == 'R') && !strcasecmp(v + 1, "IGHT"))
 	*p = 'r';
     else if ((c == 'L') || !strcasecmp(v + 1, "EFT"))

--- a/lib/common/htmltable.c
+++ b/lib/common/htmltable.c
@@ -1267,7 +1267,7 @@ static int processTbl(graph_t * g, htmltbl_t * tbl, htmlenv_t * env)
     pitem *rp;
     pitem *cp;
     Dt_t *cdict;
-    int r, c, cnt;
+    int r, c;
     htmlcell_t *cellp;
     htmlcell_t **cells;
     Dt_t *rows = tbl->u.p.rows;
@@ -1278,7 +1278,7 @@ static int processTbl(graph_t * g, htmltbl_t * tbl, htmlenv_t * env)
     Dt_t *is = openIntSet();
 
     rp = (pitem *) dtflatten(rows);
-    cnt = 0;
+    size_t cnt = 0;
     r = 0;
     while (rp) {
 	cdict = rp->u.rp;

--- a/lib/common/labels.c
+++ b/lib/common/labels.c
@@ -62,7 +62,7 @@ void make_simple_label(GVC_t * gvc, textlabel_t * lp)
     line = lineptr = N_GNEW(strlen(p) + 1, char);
     *line = 0;
     while ((c = *p++)) {
-	byte = (unsigned int) c;
+	byte = (unsigned char) c;
 	/* wingraphviz allows a combination of ascii and big-5. The latter
          * is a two-byte encoding, with the first byte in 0xA1-0xFE, and
          * the second in 0x40-0x7e or 0xa1-0xfe. We assume that the input
@@ -292,10 +292,10 @@ static char *strdup_and_subst_obj0 (char *str, void *obj, int escBackslash)
     char *tp_str = "", *hp_str = "";
     char *g_str = "\\G", *n_str = "\\N", *e_str = "\\E",
 	*h_str = "\\H", *t_str = "\\T", *l_str = "\\L";
-    int g_len = 2, n_len = 2, e_len = 2,
+    size_t g_len = 2, n_len = 2, e_len = 2,
 	h_len = 2, t_len = 2, l_len = 2,
 	tp_len = 0, hp_len = 0;
-    int newlen = 0;
+    size_t newlen = 0;
     int isEdge = 0;
     textlabel_t *tl;
     port pt;

--- a/lib/pathplan/cvt.c
+++ b/lib/pathplan/cvt.c
@@ -118,7 +118,7 @@ int Pobspath(vconfig_t * config, Ppoint_t p0, int poly0, Ppoint_t p1,
 	     int poly1, Ppolyline_t * output_route)
 {
     int i, j, *dad;
-    int opn;
+    size_t opn;
     Ppoint_t *ops;
     COORD *ptvis0, *ptvis1;
 

--- a/tclpkg/tclpathplan/tclpathplan.c
+++ b/tclpkg/tclpathplan/tclpathplan.c
@@ -221,7 +221,7 @@ static char *buildBindings(char *s1, char *s2)
  */
 {
     char *s3;
-    int l;
+    size_t l;
 
     if (s2[0] == '+') {
 	if (s1) {
@@ -413,7 +413,7 @@ static int
 vgpanecmd(ClientData clientData, Tcl_Interp * interp, int argc,
 	  char *argv[])
 {
-    int vargc, length, i, j, n, result;
+    int vargc, i, j, n, result;
     char c, *s, **vargv, vbuf[30];
     vgpane_t *vgp, **vgpp;
     point p, q, *ps;
@@ -439,7 +439,7 @@ vgpanecmd(ClientData clientData, Tcl_Interp * interp, int argc,
     vgp = *vgpp;
 
     c = argv[1][0];
-    length = strlen(argv[1]);
+    size_t length = strlen(argv[1]);
 
     if ((c == 'c') && (strncmp(argv[1], "coords", length) == 0)) {
 	if ((argc < 3)) {


### PR DESCRIPTION
Some small changes that resolve some `Wconversion` and `-Wsign-conversion` warnings. None of the changes should have effect on the behavior of the code and the program.

The warning reduction counts given in some commits were on my own machine and may not be completely accurate. On Travis there are now 58 warnings less.