### PR TITLE
Add build on CentOS 7 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,7 @@ install:
 
 script:
 - cd ${TRAVIS_BUILD_DIR}
-# Build and test code
-- ./autogen.sh
-- make
-- sudo make install
-- make check
-# Create source package to deploy
-- make dist
+- sudo ./ci/build_and_test.sh
 
 before_deploy:
 - export DEPLOYED_FILE=$(ls *.tar.gz)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ addons:
     - freeglut3-dev
     - colorgcc
 
+services:
+- docker
+
+env:
+- DOCKER_BUILD=FALSE
+- DOCKER_BUILD=TRUE
+
 install:
 # Enable colored gcc output
 - export CC=colorgcc
@@ -22,10 +29,13 @@ install:
 - cmake --build .
 - sudo make install
 - sudo ldconfig
-
+- cd ${TRAVIS_BUILD_DIR}
+- if [ ${DOCKER_BUILD} == "TRUE" ] ; then docker build -t centos7-build-env ci/centos7/ ; fi
+    
 script:
 - cd ${TRAVIS_BUILD_DIR}
-- sudo ./ci/build_and_test.sh
+- if [ ${DOCKER_BUILD} == "FALSE" ] ; then sudo ./ci/build_and_test.sh ; fi
+- if [ ${DOCKER_BUILD} == "TRUE" ] ; then docker run --rm -v `pwd`:/graphviz -w /graphviz -i -t centos7-build-env bash "ci/build_and_test.sh" ; fi
 
 before_deploy:
 - export DEPLOYED_FILE=$(ls *.tar.gz)

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Run this script from the root source directory 
+
+./autogen.sh
+make
+make install
+make check
+make dist

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -2,8 +2,37 @@
 
 # Run this script from the root source directory 
 
-./autogen.sh
-make
-make install
-make check
-make dist
+if ./autogen.sh ; then
+    echo "autogen.sh succesfull."
+else
+    echo "Error: autogen.sh failed." >&2
+    exit 1
+fi
+
+if make ; then
+    echo "make succesfull."
+else
+    echo "Error: make failed." >&2
+    exit 1
+fi
+
+if make install ; then
+    echo "make install succesfull."
+else
+    echo "Error: make install failed." >&2
+    exit 1
+fi
+
+if make check ; then
+    echo "make check succesfull."
+else
+    echo "Error: make check failed." >&2
+    exit 1
+fi
+
+if make dist ; then
+    echo "make dist succesfull."
+else
+    echo "Error: make dist failed." >&2
+    exit 1
+fi

--- a/ci/centos7/Dockerfile
+++ b/ci/centos7/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:7
+
+# Install Development tools
+RUN yum -y groupinstall 'Development Tools'
+
+# Instal autotools utilities
+RUN yum -y install libtool-ltdl-devel ghostscript swig ksh tcl
+
+# Install dependencies
+RUN yum -y install gd gd-devel qt-devel

--- a/cmd/edgepaint/Makefile.am
+++ b/cmd/edgepaint/Makefile.am
@@ -31,7 +31,7 @@ edgepaint_LDADD = \
 	$(top_builddir)/lib/edgepaint/liblab_gamut.la \
 	$(top_builddir)/lib/cgraph/libcgraph.la \
 	$(top_builddir)/lib/cdt/libcdt.la \
-	$(ANN_LIBS) -lstdc++ -lm
+	$(ANN_LIBS) -lm
 
 edgepaint.1.pdf: $(srcdir)/edgepaint.1
 	- @GROFF@ -e -Tps -man -t $(srcdir)/edgepaint.1 | @PS2PDF@ - - >edgepaint.1.pdf

--- a/cmd/mingle/Makefile.am
+++ b/cmd/mingle/Makefile.am
@@ -31,7 +31,7 @@ mingle_LDADD = \
 	$(top_builddir)/lib/common/libcommon_C.la \
 	$(top_builddir)/lib/cgraph/libcgraph.la \
 	$(top_builddir)/lib/cdt/libcdt.la \
-	$(ANN_LIBS) -lstdc++ -lm
+	$(ANN_LIBS) -lm
 
 mingle.1.pdf: $(srcdir)/mingle.1
 	- @GROFF@ -e -Tps -man -t $(srcdir)/mingle.1 | @PS2PDF@ - - >mingle.1.pdf

--- a/plugin/gdiplus/Makefile.am
+++ b/plugin/gdiplus/Makefile.am
@@ -36,7 +36,7 @@ libgvplugin_gdiplus_C_la_SOURCES = \
 libgvplugin_gdiplus_la_LDFLAGS = -version-info @GVPLUGIN_VERSION_INFO@ -Wl,"$(PLATFORMSDKLIB)\GdiPlus.lib"
 nodist_libgvplugin_gdiplus_la_SOURCES = GdiPlus*.h
 libgvplugin_gdiplus_la_SOURCES = $(libgvplugin_gdiplus_C_la_SOURCES)
-libgvplugin_gdiplus_la_LIBADD = -lgdi32 -lole32 -lstdc++ -luuid $(top_builddir)/lib/gvc/libgvc.la
+libgvplugin_gdiplus_la_LIBADD = -lgdi32 -lole32 -luuid $(top_builddir)/lib/gvc/libgvc.la
 
 if WITH_WIN32
 libgvplugin_gdiplus_la_LDFLAGS += -no-undefined


### PR DESCRIPTION
We recently discussed to whether is was possible for Travis to provide other build platforms like CentOS and Fedora. Travis itself doesn't provide CentOS or Fedora images, but it's possible to use Docker in a Travis build. I don't know how familiar you are with Docker, but it's a tool that provides visualization using containers. It can run a variety of images, including vanilla CentOS (version 5 to 7) and Fedora (version 20 to 24). I'm not sure if it's possible to have multiple architectures as well.

This pull request adds, in addition to the normal build that is still in place, a second build on a CentOS 7 image. It should be easy to add additional images and version, but this will increase the Travis build time.

While getting this to work, I removed the `-lstdc++` flag in some makefiles because it was causing errors at some point. The change log mentioned that they should be removed and the build didn't seem affected, so I hope that this doesn't cause issues.