### PR TITLE
Use `strcmp` in instead of `gvrender_comparestr`.

### DIFF
--- a/lib/gvc/gvrender.c
+++ b/lib/gvc/gvrender.c
@@ -185,11 +185,6 @@ pointf *gvrender_ptf_A(GVJ_t * job, pointf * af, pointf * AF, int n)
     return AF;
 }
 
-static int gvrender_comparestr(const void *s1, const void *s2)
-{
-    return strcmp(*(char**)s1, *(char**)s2);
-}
-
 static void gvrender_resolve_color(gvrender_features_t * features,
 				   char *name, gvcolor_t * color)
 {
@@ -202,8 +197,8 @@ static void gvrender_resolve_color(gvrender_features_t * features,
     if (!features->knowncolors
 	||
 	(bsearch
-	 (&tok, features->knowncolors, features->sz_knowncolors,
-	  sizeof(char *), gvrender_comparestr)) == NULL) {
+	 (tok, features->knowncolors, features->sz_knowncolors,
+	  sizeof(char *), (__compar_fn_t) strcmp)) == NULL) {
 	/* if tok was not found in known_colors */
 	rc = colorxlate(name, color, features->color_type);
 	if (rc != COLOR_OK) {

--- a/lib/gvc/gvrender.c
+++ b/lib/gvc/gvrender.c
@@ -198,7 +198,7 @@ static void gvrender_resolve_color(gvrender_features_t * features,
 	||
 	(bsearch
 	 (tok, features->knowncolors, features->sz_knowncolors,
-	  sizeof(char *), (__compar_fn_t) strcmp)) == NULL) {
+	  sizeof(char *), (int(*)(const void*, const void*)) strcmp)) == NULL) {
 	/* if tok was not found in known_colors */
 	rc = colorxlate(name, color, features->color_type);
 	if (rc != COLOR_OK) {


### PR DESCRIPTION
I saw John working on this and had a look at it as well. `bsearch` is used in this function to find a string in a string array. It's not needed to pass the address of `tok` to the function, because `tok` is already a pointer. `gvrender_comparestr` should then cast the values to `(const char)` instead of `*(char**)`, because `s1` and `s2` are strings, not pointers to a string. With this change the function only calls `strcmp`, so passing `strcmp` to `bsearch` has the same effect and `gvrender_comparestr` can be removed.
This gets rid of all the `-Wcast-qual` warnings.