### PR TITLE
Enhanced Travis Nightly Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ before_deploy:
 - echo "deploying ${DEPLOYED_FILE} to GitHub releases"
 - sudo chown travis ${DEPLOYED_FILE}
 
+# If no tag is set, deploy as nightly
+- if [ !${TRAVIS_TAG} ] ; then export TRAVIS_TAG=Nightly ; fi
+
 deploy:
   provider: releases
   api_key:

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ December 5, 2016
 	- Extensive code cleanup (Erwin Janssen)
 	- Removal of libgd source - use vanilla libgd from separate install 
 	- Windows builds (Erwin Janssen)
-	- Appveyor CI for Mac builds (Erwin Janssen)
+	- Appveyor CI for automated Windows build testing (Erwin Janssen)
 	- Travis CI for Fedora/Centos builds (Erwin Janssen)
 	- Added JSON output format, -Tjson  (Emden Gansner)
 	- New curved arrowhead, cylinder node shape.


### PR DESCRIPTION
Instead of publishing a new release with an "untagged" name on every
Travis build, this configuration will deploy all these nightlies to a
special "Nightly" release tag.