### PR TITLE
build: Use EGREP to generate graphviz_version.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ dist-hook:
 BUILT_SOURCES = $(top_builddir)/graphviz_version.h
 
 $(top_builddir)/graphviz_version.h: config.h
-	$(GREP) 'PACKAGE\|VERSION\|GVPLUGIN' config.h > $(top_builddir)/graphviz_version.h
+	$(EGREP) 'PACKAGE|VERSION|GVPLUGIN' config.h > $(top_builddir)/graphviz_version.h
 
 EXTRA_DIST = $(txt) $(html) graphviz.spec.in graphviz.spec \
 	autogen.sh config/depcomp config/config.rpath \


### PR DESCRIPTION
According to POSIX, '|' only works as an alternation character in grep
when it is extended regular expression mode (egrep, or grep -E).

This is not an issue most of the time because GNU grep accepts it in
non-extended expressions as well, but other grep implementations
adhering to the standard will fail to match the pattern used to generate
graphviz_version.h.

Switching to EGREP (which also requires not escaping the '|'s) makes it
work for all implementations.