### PR TITLE
Remove unused FPE initialization from dot.c

### DIFF
--- a/cmd/dot/dot.c
+++ b/cmd/dot/dot.c
@@ -36,19 +36,6 @@ __declspec(dllimport) int GvExitOnUsage;
 #include <unistd.h>
 #endif
 
-#if defined(HAVE_FENV_H) && defined(HAVE_FEENABLEEXCEPT)
-/* _GNU_SOURCE is needed for feenableexcept to be defined in fenv.h on GNU
- * systems.   Presumably it will do no harm on other systems. */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-# include <fenv.h>
-#elif HAVE_FPU_CONTROL_H
-# include <fpu_control.h>
-#elif HAVE_SYS_FPU_H
-# include <sys/fpu.h>
-#endif
-
 static GVC_t *Gvc;
 static graph_t * G;
 
@@ -69,47 +56,6 @@ static void fperr(int s)
     fprintf(stderr, "caught SIGFPE %d\n", s);
     /* signal (s, SIG_DFL); raise (s); */
     exit(1);
-}
-
-static void fpinit(void)
-{
-#if defined(HAVE_FENV_H) && defined(HAVE_FEENABLEEXCEPT)
-    int exc = 0;
-# ifdef FE_DIVBYZERO
-    exc |= FE_DIVBYZERO;
-# endif
-# ifdef FE_OVERFLOW
-    exc |= FE_OVERFLOW;
-# endif
-# ifdef FE_INVALID
-    exc |= FE_INVALID;
-# endif
-    feenableexcept(exc);
-
-#ifdef HAVE_FESETENV
-#ifdef FE_NONIEEE_ENV
-    fesetenv (FE_NONIEEE_ENV);
-#endif
-#endif
-
-#elif  HAVE_FPU_CONTROL_H
-    /* On s390-ibm-linux, the header exists, but the definitions
-     * of the masks do not.  I assume this is temporary, but until
-     * there's a real implementation, it's probably safest to not
-     * adjust the FPU on this platform.
-     */
-# if defined(_FPU_MASK_IM) && defined(_FPU_MASK_DM) && defined(_FPU_MASK_ZM) && defined(_FPU_GETCW)
-    fpu_control_t fpe_flags = 0;
-    _FPU_GETCW(fpe_flags);
-    fpe_flags &= ~_FPU_MASK_IM;	/* invalid operation */
-    fpe_flags &= ~_FPU_MASK_DM;	/* denormalized operand */
-    fpe_flags &= ~_FPU_MASK_ZM;	/* zero-divide */
-    /*fpe_flags &= ~_FPU_MASK_OM;        overflow */
-    /*fpe_flags &= ~_FPU_MASK_UM;        underflow */
-    /*fpe_flags &= ~_FPU_MASK_PM;        precision (inexact result) */
-    _FPU_SETCW(fpe_flags);
-# endif
-#endif
 }
 #endif
 #endif
@@ -160,7 +106,6 @@ int main(int argc, char **argv)
     signal(SIGUSR1, gvToggle);
     signal(SIGINT, intr);
 #ifndef NO_FPERR
-    fpinit();
     signal(SIGFPE, fperr);
 #endif
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -427,9 +427,9 @@ dnl Checks for header files
 # AC_HEADER_STDC
 AC_CHECK_HEADERS(stdarg.h stddef.h stddef.h malloc.h \
 	fcntl.h search.h pthread.h values.h float.h limits.h termios.h \
-	errno.h time.h unistd.h fenv.h strings.h setjmp.h \
-	sys/time.h sys/times.h sys/types.h sys/select.h fpu_control.h \
-	sys/fpu.h sys/socket.h sys/stat.h sys/mman.h \
+	errno.h time.h unistd.h strings.h setjmp.h \
+	sys/time.h sys/times.h sys/types.h sys/select.h \
+	sys/socket.h sys/stat.h sys/mman.h \
 	sys/ioctl.h sys/inotify.h langinfo.h libintl.h crt_externs.h)
 AC_HEADER_TIME
 AC_HEADER_DIRENT
@@ -447,7 +447,7 @@ AC_SUBST([MATH_LIBS])
 
 # Check for functions that might need -lm
 LIBS="$LIBS $MATH_LIBS"
-AC_CHECK_FUNCS([feenableexcept fesetenv log2 sincos])
+AC_CHECK_FUNCS([log2 sincos])
 
 LIBS=$save_LIBS
 

--- a/windows/include/config.h
+++ b/windows/include/config.h
@@ -68,15 +68,6 @@
 /* Define to 1 if you have the <expat.h> header file. */
 #define HAVE_EXPAT_H 1
 
-/* Define to 1 if you have the `feenableexcept' function. */
-/* #undef HAVE_FEENABLEEXCEPT */
-
-/* Define to 1 if you have the <fenv.h> header file. */
-#define HAVE_FENV_H 1
-
-/* Define to 1 if you have the `fesetenv' function. */
-#define HAVE_FESETENV 1
-
 /* Define if FILE structure provides _cnt */
 #define HAVE_FILE_CNT 1
 
@@ -94,9 +85,6 @@
 
 /* Define if you have the fontconfig library */
 #define HAVE_FONTCONFIG 1
-
-/* Define to 1 if you have the <fpu_control.h> header file. */
-/* #undef HAVE_FPU_CONTROL_H */
 
 /* Define if you have the freetype2 library */
 #define HAVE_FREETYPE2 1
@@ -312,9 +300,6 @@
 /* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
    */
 /* #undef HAVE_SYS_DIR_H */
-
-/* Define to 1 if you have the <sys/fpu.h> header file. */
-/* #undef HAVE_SYS_FPU_H */
 
 /* Define to 1 if you have the <sys/inotify.h> header file. */
 /* #undef HAVE_SYS_INOTIFY_H */


### PR DESCRIPTION
In cmd/dot/dot.c, non standard floating point exceptions are enabled in a platform specific way in a sequence of `ifdef`s. However, this is never used because:
- The rest of the code never checks for set floating point exception flags (with `fetestexcept` for example).
- The check that toggles the whole block, `ifndef NO_FPERR` is almost false. `NO_FPERR` is always defined on Windows and only disabled on specific platforms that do not support `-ffast-math`.

In conclusion, the code adds unnecessary complexity and should be removed. Do you agree or am I missing something?