### PR TITLE
Fix font errors on Windows with binary outputs

### DIFF
--- a/cmd/smyrna/smyrna.vcxproj
+++ b/cmd/smyrna/smyrna.vcxproj
@@ -93,7 +93,10 @@ copy $(SolutionDir)windows\dependencies\GTK2\bin\libgdk_pixbuf-2.0-0.dll $(OutDi
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libglade-2.0-0.dll $(OutDir)libglade-2.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libatk-1.0-0.dll $(OutDir)libatk-1.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libgtk-win32-2.0-0.dll $(OutDir)libgtk-win32-2.0-0.dll
-copy $(SolutionDir)windows\dependencies\freeglut\bin\freeglut.dll $(OutDir)freeglut.dll</Command>
+copy $(SolutionDir)windows\dependencies\freeglut\bin\freeglut.dll $(OutDir)freeglut.dll
+xcopy /E $(SolutionDir)windows\dependencies\GTK2\lib\pango $(OutDir)..\lib\pango\
+if not exist "$(OutDir)..\etc\pango\" mkdir $(OutDir)..\etc\pango\
+$(SolutionDir)windows\dependencies\GTK2\bin\pango-querymodules.exe &gt; $(OutDir)..\etc\pango\pango.modules</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -138,7 +141,10 @@ copy $(SolutionDir)windows\dependencies\GTK2\bin\libgdk_pixbuf-2.0-0.dll $(OutDi
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libglade-2.0-0.dll $(OutDir)libglade-2.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libatk-1.0-0.dll $(OutDir)libatk-1.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libgtk-win32-2.0-0.dll $(OutDir)libgtk-win32-2.0-0.dll
-copy $(SolutionDir)windows\dependencies\freeglut\bin\freeglut.dll $(OutDir)freeglut.dll</Command>
+copy $(SolutionDir)windows\dependencies\freeglut\bin\freeglut.dll $(OutDir)freeglut.dll
+xcopy /E $(SolutionDir)windows\dependencies\GTK2\lib\pango $(OutDir)..\lib\pango\
+if not exist "$(OutDir)..\etc\pango\" mkdir $(OutDir)..\etc\pango\
+$(SolutionDir)windows\dependencies\GTK2\bin\pango-querymodules.exe &gt; $(OutDir)..\etc\pango\pango.modules</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/plugin/pango/gvplugin_pango.vcxproj
+++ b/plugin/pango/gvplugin_pango.vcxproj
@@ -84,7 +84,10 @@ copy $(SolutionDir)windows\dependencies\GTK2\bin\libgobject-2.0-0.dll $(OutDir)l
 copy $(SolutionDir)windows\dependencies\GTK2\bin\intl.dll $(OutDir)intl.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libgmodule-2.0-0.dll $(OutDir)libgmodule-2.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangoft2-1.0-0.dll $(OutDir)libpangoft2-1.0-0.dll
-copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangowin32-1.0-0.dll $(OutDir)libpangowin32-1.0-0.dll</Command>
+copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangowin32-1.0-0.dll $(OutDir)libpangowin32-1.0-0.dll
+xcopy /E $(SolutionDir)windows\dependencies\GTK2\lib\pango $(OutDir)..\lib\pango\
+if not exist "$(OutDir)..\etc\pango\" mkdir $(OutDir)..\etc\pango\
+$(SolutionDir)windows\dependencies\GTK2\bin\pango-querymodules.exe &gt; $(OutDir)..\etc\pango\pango.modules</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -121,7 +124,10 @@ copy $(SolutionDir)windows\dependencies\GTK2\bin\libgobject-2.0-0.dll $(OutDir)l
 copy $(SolutionDir)windows\dependencies\GTK2\bin\intl.dll $(OutDir)intl.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libgmodule-2.0-0.dll $(OutDir)libgmodule-2.0-0.dll
 copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangoft2-1.0-0.dll $(OutDir)libpangoft2-1.0-0.dll
-copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangowin32-1.0-0.dll $(OutDir)libpangowin32-1.0-0.dll</Command>
+copy $(SolutionDir)windows\dependencies\GTK2\bin\libpangowin32-1.0-0.dll $(OutDir)libpangowin32-1.0-0.dll
+xcopy /E $(SolutionDir)windows\dependencies\GTK2\lib\pango $(OutDir)..\lib\pango\
+if not exist "$(OutDir)..\etc\pango\" mkdir $(OutDir)..\etc\pango\
+$(SolutionDir)windows\dependencies\GTK2\bin\pango-querymodules.exe &gt; $(OutDir)..\etc\pango\pango.modules</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Outputs like 'png' didn't render the text properly on Windows (rectangles
instead of letters). The cause was that Pango was missings its modules. This
change adds post build commands to the `smyrna` en `gvplugin_pango` Visual
Studio projects, so the required modules are copied and then recognized by
pango.
Fixes issue #1186