### PR TITLE
Include <sys/types.h> when available

### DIFF
--- a/config-cmake.h.in
+++ b/config-cmake.h.in
@@ -5,6 +5,7 @@
 #cmakedefine HAVE_MALLOC_H
 #cmakedefine HAVE_STAT_H
 #cmakedefine HAVE_SYS_STAT_H
+#cmakedefine HAVE_SYS_TYPES_H
 #cmakedefine HAVE_UNISTD_H
 
 // Functions


### PR DESCRIPTION
Trivial commit to `#include <sys/types.h>` in `config.h`. That include file defines `ssize_t`.