### PR TITLE
Add 'imagepos' node attribute to control image placement

### DIFF
--- a/doc/infosrc/attrs
+++ b/doc/infosrc/attrs
@@ -511,6 +511,21 @@ a semicolon (for Windows) or a colon (all other OS).
 The first directory in which a file of the given name is found will be used to
 load the image. If <tt>imagepath</tt> is not set, relative pathnames for the image
 file will be interpreted with respect to the current working directory.
+:imagepos:N:string:"mc":;
+Attribute controlling how an image is positioned within its containing node.  This
+only has an effect when the image is smaller than the containing node.  The
+default is to be centered both horizontally and vertically.  Valid values:
+<TABLE>
+<TR><TD>tl</TD><TD>Top Left</TD></TR>
+<TR><TD>tc</TD><TD>Top Centered</TD></TR>
+<TR><TD>tr</TD><TD>Top Right</TD></TR>
+<TR><TD>ml</TD><TD>Middle Left</TD></TR>
+<TR><TD>mc</TD><TD>Middle Centered <I>(the default)</I></TD></TR>
+<TR><TD>mr</TD><TD>Middle Right</TD></TR>
+<TR><TD>bl</TD><TD>Bottom Left</TD></TR>
+<TR><TD>bc</TD><TD>Bottom Centered</TD></TR>
+<TR><TD>br</TD><TD>Bottom Right</TD></TR>
+</TABLE>
 :imagescale:N:bool/string:false:;
 Attribute controlling how an image fills its
 containing node. In general, the image is given its natural size,

--- a/lib/common/globals.h
+++ b/lib/common/globals.h
@@ -100,7 +100,7 @@ extern "C" {
 	*N_fontsize, *N_fontname, *N_fontcolor, *N_margin,
 	*N_label, *N_xlabel, *N_nojustify, *N_style, *N_showboxes,
 	*N_sides, *N_peripheries, *N_ordering, *N_orientation,
-	*N_skew, *N_distortion, *N_fixed, *N_imagescale, *N_layer,
+	*N_skew, *N_distortion, *N_fixed, *N_imagescale, *N_imagepos, *N_layer,
 	*N_group, *N_comment, *N_vertices, *N_z,
 	*N_penwidth, *N_gradientangle;
     EXTERN Agsym_t

--- a/lib/common/htmltable.c
+++ b/lib/common/htmltable.c
@@ -622,7 +622,7 @@ static void emit_html_img(GVJ_t * job, htmlimg_t * cp, htmlenv_t * env)
 	scale = env->imgscale;
     assert(cp->src);
     assert(cp->src[0]);
-    gvrender_usershape(job, cp->src, A, 4, TRUE, scale);
+    gvrender_usershape(job, cp->src, A, 4, TRUE, scale, "mc");
 }
 
 static void emit_html_cell(GVJ_t * job, htmlcell_t * cp, htmlenv_t * env)

--- a/lib/common/input.c
+++ b/lib/common/input.c
@@ -792,6 +792,7 @@ void graph_init(graph_t * g, boolean use_rankdir)
     N_distortion = agfindnodeattr(g, "distortion");
     N_fixed = agfindnodeattr(g, "fixedsize");
     N_imagescale = agfindnodeattr(g, "imagescale");
+    N_imagepos = agfindnodeattr(g, "imagepos");
     N_nojustify = agfindnodeattr(g, "nojustify");
     N_layer = agfindnodeattr(g, "layer");
     N_group = agfindnodeattr(g, "group");

--- a/lib/common/shapes.c
+++ b/lib/common/shapes.c
@@ -2965,7 +2965,8 @@ static void poly_gencode(GVJ_t * job, node_t * n)
 	    }
 	}
 	gvrender_usershape(job, name, AF, sides, filled,
-			   late_string(n, N_imagescale, "false"));
+			   late_string(n, N_imagescale, "false"),
+			   late_string(n, N_imagepos, "mc"));
 	filled = FALSE;		/* with user shapes, we have done the fill if needed */
     }
 

--- a/lib/common/usershape.h
+++ b/lib/common/usershape.h
@@ -34,6 +34,18 @@ extern "C" {
 	IMAGESCALE_BOTH    /* scale image to fit without regard for aspect ratio */
     } imagescale_t;
 
+    typedef enum {
+        IMAGEPOS_TOP_LEFT,      /* top left */
+        IMAGEPOS_TOP_CENTER,    /* top center */
+        IMAGEPOS_TOP_RIGHT,     /* top right */
+        IMAGEPOS_MIDDLE_LEFT,   /* middle left */
+        IMAGEPOS_MIDDLE_CENTER, /* middle center (true center, the default)*/
+        IMAGEPOS_MIDDLE_RIGHT,  /* middle right */
+        IMAGEPOS_BOTTOM_LEFT,   /* bottom left */
+        IMAGEPOS_BOTTOM_CENTER, /* bottom center */
+        IMAGEPOS_BOTTOM_RIGHT   /* bottom right */
+    } imagepos_t;
+
     typedef struct usershape_s usershape_t;
 
     struct usershape_s {

--- a/lib/gvc/gvcproc.h
+++ b/lib/gvc/gvcproc.h
@@ -113,7 +113,7 @@
 			int arrow_at_start, int arrow_at_end, boolean filled);
     extern void gvrender_polyline(GVJ_t * job, pointf * AF, int n);
     extern void gvrender_comment(GVJ_t * job, char *str);
-    extern void gvrender_usershape(GVJ_t * job, char *name, pointf * AF, int n, boolean filled, char *imagescale);
+    extern void gvrender_usershape(GVJ_t * job, char *name, pointf * AF, int n, boolean filled, char *imagescale, char *imagepos);
 
 /* layout */
 


### PR DESCRIPTION
I often find myself wanting to use icons to help categorize graphviz nodes in a quick visual fashion, but I typically don't like that the image is centered right in the middle of the node.  I know that I can control image placement somewhat by using HTML inside nodes, with `<IMG>` tags, but I generally don't like how large that makes the individual nodes.

So, this pull request adds in an "imagepos" node attribute which can align node images in one of nine positions, from Top Left to Bottom Right.  It defaults to fully centered, as graphviz does currently.

Two things to note:

1. I wasn't sure how this would interact with `lib/common/htmltable.c`, so for now I just set that file to hardcode the fully-centered option.  It's possible I should be doing something more clever there.
2. My distro doesn't seem to package `ksh`, which the documentation-generation scripts appear to use.  I updated `doc/infosrc/attrs`, though.

Let me know if this isn't up to snuff, esp. WRT the "htmltable" stuff, though I could probably use some pointers if you'd like me to fix up that area of things.