### PR TITLE
Allow to override build date

### DIFF
--- a/tclpkg/gv/gv_doc_template.tcl
+++ b/tclpkg/gv/gv_doc_template.tcl
@@ -1,4 +1,9 @@
-.TH gv 3[string tolower $lang] \"[clock format [clock seconds] -format "%d %B %Y"]\"
+.TH gv 3[string tolower $lang] \"[
+    set buildtime [clock seconds]
+    if { [info exists ::env(SOURCE_DATE_EPOCH) ] } {
+         set buildtime $::env(SOURCE_DATE_EPOCH)
+    }
+    clock format $buildtime -format "%d %B %Y"]\"
 
 .SH NAME
 


### PR DESCRIPTION
that gets written to man pages
in order to allow for reproducible builds.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.