### PR TITLE
add argument --enable-debug to configure.ac for gdb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -407,6 +407,29 @@ fi
 AM_CONDITIONAL(RC_IS_RC, [test "x$RC" = "xrc"])
 AM_CONDITIONAL(RC_IS_WINDRES, [test "x$RC" = "xwindres"])
 
+# debug
+AC_ARG_ENABLE([debug],
+	AS_HELP_STRING([--enable-debug],[Compile the debug version (default: disabled)]),
+	[enable_debug=$enableval],
+	[enable_debug=no])
+AM_CONDITIONAL([DEBUG], [test $enable_debug = "yes"])
+if test "x$enable_debug" = "xyes"; then
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  changequote([,])
+  dnl add -O0 only if GCC or ICC is used
+  if test "$GCC" = "yes" || test "$ICC" = "yes"; then
+    CFLAGS="$CFLAGS -g -O0 -Wall"
+    CXXFLAGS="$CXXFLAGS -g -O0 -Wall"
+  fi
+else
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-g//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-g//g'`
+  changequote([,])
+fi
+
 dnl -----------------------------------
 dnl Check for various typedefs and provide substitutes if they do not exist.
 


### PR DESCRIPTION
This patch will add an argument '--enable-debug' to configure.ac to compile the C source with the gcc arguments "-g -O0" for gdb.
