### PR TITLE
Sort entries in config6

### DIFF
--- a/lib/gvc/gvconfig.c
+++ b/lib/gvc/gvconfig.c
@@ -437,7 +437,7 @@ static void config_rescan(GVC_t *gvc, char *config_path)
 #if defined(_WIN32)
     rc = glob(gvc, config_glob, GLOB_NOSORT, NULL, &globbuf);
 #else
-    rc = glob(config_glob, GLOB_NOSORT, NULL, &globbuf);
+    rc = glob(config_glob, 0, NULL, &globbuf);
 #endif
     if (rc == 0) {
 	for (i = 0; i < globbuf.gl_pathc; i++) {


### PR DESCRIPTION
so that openSUSE's installation-images package builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

`man 3 glob` says:
```
GLOB_NOSORT
      Don't sort the returned pathnames.  The only reason to  do  this
      is  to save processing time.  By default, the returned pathnames
      are sorted.
```